### PR TITLE
feat(mpris-smtc): integrate OS media session support via JMTC

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
 
     implementation(libs.bundles.ktor)
     implementation(libs.bundles.tamboui)
+    implementation(libs.jmtc)
 }
 
 val appVersion = "1.0.0"

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
@@ -9,6 +9,7 @@ import com.github.adriianh.cli.tui.component.PlaylistPickerOverlay
 import com.github.adriianh.cli.tui.graphics.ClearGraphicsElement
 import com.github.adriianh.cli.tui.handler.*
 import com.github.adriianh.cli.tui.player.AudioPlayer
+import com.github.adriianh.cli.tui.player.MediaSessionManager
 import com.github.adriianh.cli.tui.screen.renderHomeScreen
 import com.github.adriianh.cli.tui.screen.renderLibraryScreen
 import com.github.adriianh.cli.tui.screen.renderSearchScreen
@@ -64,13 +65,32 @@ class MeloScreen(
     /** Exposes the protected runner() for internal extension functions. */
     internal fun appRunner() = runner()
 
-    internal val audioPlayer = AudioPlayer(
+    internal val mediaSession = MediaSessionManager(
+        onPlayPause = {
+            runner()?.runOnRenderThread { togglePlayPause() }
+        },
+        onNext = {
+            runner()?.runOnRenderThread { seekForward() }
+        },
+        onPrevious = {
+            runner()?.runOnRenderThread { seekBackward() }
+        },
+        onStop = {
+            runner()?.runOnRenderThread {
+                audioPlayer.stop()
+                state = state.copy(isPlaying = false, progress = 0.0)
+            }
+        },
+    )
+
+    internal val audioPlayer: AudioPlayer = AudioPlayer(
         scope = scope,
         onProgress = { elapsedMs ->
             runner()?.runOnRenderThread {
                 val duration = state.nowPlaying?.durationMs ?: 0L
                 val progress = if (duration > 0) (elapsedMs.toDouble() / duration).coerceIn(0.0, 1.0) else 0.0
                 state = state.copy(progress = progress)
+                mediaSession.updatePosition(elapsedMs)
             }
         },
         onFinish = {
@@ -82,6 +102,7 @@ class MeloScreen(
         onError = { err ->
             runner()?.runOnRenderThread {
                 state = state.copy(isPlaying = false, isLoadingAudio = false, audioError = err.message)
+                mediaSession.notifyStopped()
             }
         },
     )
@@ -169,6 +190,7 @@ class MeloScreen(
     override fun configure(): TuiConfig = TuiConfig.builder().mouseCapture(true).build()
 
     override fun onStart() {
+        mediaSession.init()
         scope.launch {
             getFavorites().collect { tracks ->
                 runner()?.runOnRenderThread { state = state.copy(favorites = tracks) }
@@ -205,6 +227,7 @@ class MeloScreen(
         marqueeJob?.cancel()
         playlistTracksJob?.cancel()
         audioPlayer.stop()
+        mediaSession.destroy()
         scope.cancel()
     }
 

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenPlaybackHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenPlaybackHandlers.kt
@@ -34,6 +34,7 @@ internal fun MeloScreen.playTrack(track: Track) {
             }
             state = state.copy(isPlaying = true, isLoadingAudio = false)
             audioPlayer.play(url)
+            mediaSession.updateTrack(track, track.durationMs)
         }
     }
     checkIsFavorite(track.id)
@@ -41,8 +42,15 @@ internal fun MeloScreen.playTrack(track: Track) {
 
 internal fun MeloScreen.togglePlayPause() {
     if (state.nowPlaying == null || state.isLoadingAudio) return
-    if (state.isPlaying) { audioPlayer.pause(); state = state.copy(isPlaying = false) }
-    else { audioPlayer.resume(); state = state.copy(isPlaying = true) }
+    if (state.isPlaying) {
+        audioPlayer.pause()
+        state = state.copy(isPlaying = false)
+        mediaSession.notifyPaused()
+    } else {
+        audioPlayer.resume()
+        state = state.copy(isPlaying = true)
+        mediaSession.notifyResumed()
+    }
 }
 
 internal fun MeloScreen.adjustVolume(delta: Int) {

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/player/MediaSessionManager.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/player/MediaSessionManager.kt
@@ -1,0 +1,164 @@
+package com.github.adriianh.cli.tui.player
+
+import com.github.adriianh.core.domain.model.Track
+import io.github.selemba1000.JMTC
+import io.github.selemba1000.JMTCButtonCallback
+import io.github.selemba1000.JMTCCallbacks
+import io.github.selemba1000.JMTCEnabledButtons
+import io.github.selemba1000.JMTCMediaType
+import io.github.selemba1000.JMTCMusicProperties
+import io.github.selemba1000.JMTCPlayingState
+import io.github.selemba1000.JMTCSettings
+import io.github.selemba1000.JMTCTimelineProperties
+import java.io.File
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.file.Files
+
+/**
+ * Integrates with the OS media session layer via JMTC:
+ *   - Linux  → MPRIS2 over D-Bus
+ *   - Windows → SystemMediaTransportControls (SMTC)
+ *   - macOS  → not yet supported by JMTC
+ *
+ * Exposes callbacks so [AudioPlayer] / [MeloScreen] can react to
+ * media-key presses from the OS or lock-screen controls.
+ */
+class MediaSessionManager(
+    private val onPlayPause: () -> Unit = {},
+    private val onNext: () -> Unit = {},
+    private val onPrevious: () -> Unit = {},
+    private val onStop: () -> Unit = {},
+) {
+    private var jmtc: JMTC? = null
+    private var initialized = false
+
+    fun init() {
+        if (initialized) return
+        try {
+            jmtc = JMTC.getInstance(JMTCSettings("melo", "melo"))
+
+            val callbacks = JMTCCallbacks()
+            callbacks.onPlay = JMTCButtonCallback {
+                jmtc?.playingState = JMTCPlayingState.PLAYING
+                onPlayPause()
+            }
+            callbacks.onPause = JMTCButtonCallback {
+                jmtc?.playingState = JMTCPlayingState.PAUSED
+                onPlayPause()
+            }
+            callbacks.onStop = JMTCButtonCallback {
+                jmtc?.playingState = JMTCPlayingState.STOPPED
+                onStop()
+            }
+            callbacks.onNext = JMTCButtonCallback { onNext() }
+            callbacks.onPrevious = JMTCButtonCallback { onPrevious() }
+
+            jmtc?.setCallbacks(callbacks)
+            jmtc?.mediaType = JMTCMediaType.Music
+            jmtc?.enabledButtons = JMTCEnabledButtons(
+                /* play     */ true,
+                /* pause    */ true,
+                /* stop     */ false,
+                /* next     */ true,
+                /* previous */ true,
+            )
+            jmtc?.enabled = true
+            jmtc?.playingState = JMTCPlayingState.STOPPED
+            jmtc?.updateDisplay()
+
+            initialized = true
+        } catch (_: Exception) { }
+    }
+
+    /** Called when a new track starts playing. */
+    fun updateTrack(track: Track, durationMs: Long) {
+        val instance = jmtc ?: return
+        try {
+            val artworkFile = track.artworkUrl?.let { downloadArtworkToTempFile(it) }
+
+            instance.mediaProperties = JMTCMusicProperties(
+                /* title       */ track.title,
+                /* artist      */ track.artist,
+                /* albumTitle  */ track.album,
+                /* albumArtist */ track.artist,
+                /* genres      */ emptyArray(),
+                /* albumTracks */ 0,
+                /* track       */ 0,
+                /* art         */ artworkFile,
+            )
+            instance.setTimelineProperties(
+                JMTCTimelineProperties(
+                    /* start     */ 0L,
+                    /* end       */ durationMs * 1_000L, // JMTC uses microseconds
+                    /* seekStart */ 0L,
+                    /* seekEnd   */ durationMs * 1_000L,
+                )
+            )
+            instance.playingState = JMTCPlayingState.PLAYING
+            instance.updateDisplay()
+        } catch (_: Exception) {}
+    }
+
+    /** Called when playback is paused. */
+    fun notifyPaused() {
+        try {
+            jmtc?.playingState = JMTCPlayingState.PAUSED
+            jmtc?.updateDisplay()
+        } catch (_: Exception) {}
+    }
+
+    /** Called when playback is resumed. */
+    fun notifyResumed() {
+        try {
+            jmtc?.playingState = JMTCPlayingState.PLAYING
+            jmtc?.updateDisplay()
+        } catch (_: Exception) {}
+    }
+
+    /** Called when playback position changes. [positionMs] in milliseconds. */
+    fun updatePosition(positionMs: Long) {
+        try {
+            jmtc?.setPosition(positionMs * 1_000L) // JMTC uses microseconds
+        } catch (_: Exception) {}
+    }
+
+    /** Called when playback stops entirely. */
+    fun notifyStopped() {
+        try {
+            jmtc?.playingState = JMTCPlayingState.STOPPED
+            jmtc?.updateDisplay()
+        } catch (_: Exception) {}
+    }
+
+    fun destroy() {
+        try {
+            jmtc?.enabled = false
+        } catch (_: Exception) {}
+        jmtc = null
+        initialized = false
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /**
+     * Downloads the artwork from [url] and writes it to a temp file.
+     * JMTC expects a [File] rather than raw bytes for the album art.
+     * Returns null if the download fails.
+     */
+    private fun downloadArtworkToTempFile(url: String): File? = try {
+        val client = HttpClient.newHttpClient()
+        val request = HttpRequest.newBuilder(URI.create(url)).GET().build()
+        val response = client.send(request, HttpResponse.BodyHandlers.ofByteArray())
+        if (response.statusCode() == 200) {
+            val tmp = Files.createTempFile("melo-art-", ".jpg").toFile()
+            tmp.deleteOnExit()
+            tmp.writeBytes(response.body())
+            tmp
+        } else null
+    } catch (_: Exception) {
+        null
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ tamboui = "0.1.0"
 scrimage = "4.1.3"
 graalvm = "0.10.4"
 sqldelight = "2.0.2"
+jmtc = "0.0.3"
 
 [libraries]
 kotlinGradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -40,6 +41,7 @@ sqldelightRuntime = { module = "app.cash.sqldelight:runtime", version.ref = "sql
 sqldelightCoroutinesExtensions = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqldelightSqliteDriver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 sqldelightGradlePlugin = { module = "app.cash.sqldelight:gradle-plugin", version.ref = "sqldelight" }
+jmtc = { module = "io.github.selemba1000:JavaMediaTransportControls", version.ref = "jmtc" }
 
 [bundles]
 kotlinxEcosystem = ["kotlinxDatetime", "kotlinxSerialization", "kotlinxCoroutines"]


### PR DESCRIPTION
## What
Integrates Melo with the OS media session layer using the JMTC library, enabling MPRIS2 on Linux and SMTC on Windows. The app is now recognized as a real media player by the OS.

## Why
Media keys (play/pause, next, previous) and lock-screen/taskbar controls should work natively with Melo, just like any other media player.

## How
Introduced `MediaSessionManager` as a thin wrapper around JMTC, keeping the integration isolated and replaceable. It is initialized on screen start and destroyed on screen stop, with all playback events (track change, pause, resume, seek, stop) forwarded to the OS session.

JMTC fails silently if D-Bus or COM is unavailable, so the app remains fully functional on unsupported environments.

## Testing
- Manually tested on Linux (MPRIS2 via D-Bus): media keys, lock-screen controls and playerctl all work correctly
- Windows (SMTC) pending — to be verified separately