### PR TITLE
feat(tui): add Now Playing screen with synced lyrics

### DIFF
--- a/cli/src/main/kotlin/com/github/adriianh/cli/command/MeloCommand.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/command/MeloCommand.kt
@@ -46,6 +46,7 @@ class MeloCommand : CliktCommand(
         val loadMoreTracks: LoadMoreTracksUseCase by inject()
         val getTrack: GetTrackUseCase by inject()
         val getLyrics: GetLyricsUseCase by inject()
+        val getSyncedLyrics: GetSyncedLyricsUseCase by inject()
         val getSimilarTracks: GetSimilarTracksUseCase by inject()
         val getFavorites: GetFavoritesUseCase by inject()
         val addFavorite: AddFavoriteUseCase by inject()
@@ -64,7 +65,7 @@ class MeloCommand : CliktCommand(
 
         try {
             MeloScreen(
-                searchTracks, loadMoreTracks, getTrack, getLyrics, getSimilarTracks,
+                searchTracks, loadMoreTracks, getTrack, getLyrics, getSyncedLyrics, getSimilarTracks,
                 getFavorites, addFavorite, removeFavorite, isFavorite,
                 getRecentTracks, recordPlay, getStream,
                 getPlaylists, getPlaylistTracks, createPlaylist, renamePlaylist,

--- a/cli/src/main/kotlin/com/github/adriianh/cli/di/AppModule.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/di/AppModule.kt
@@ -98,6 +98,7 @@ val appModule = module {
     single { LoadMoreTracksUseCase(get()) }
     single { GetTrackUseCase(get()) }
     single { GetLyricsUseCase(get()) }
+    single { GetSyncedLyricsUseCase(get()) }
     single { GetSimilarTracksUseCase(get()) }
     single { GetFavoritesUseCase(get()) }
     single { AddFavoriteUseCase(get()) }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
@@ -12,6 +12,7 @@ import com.github.adriianh.cli.tui.player.AudioPlayer
 import com.github.adriianh.cli.tui.player.MediaSessionManager
 import com.github.adriianh.cli.tui.screen.renderHomeScreen
 import com.github.adriianh.cli.tui.screen.renderLibraryScreen
+import com.github.adriianh.cli.tui.screen.renderNowPlayingScreen
 import com.github.adriianh.cli.tui.screen.renderSearchScreen
 import com.github.adriianh.cli.tui.util.TextAnimationUtil.marqueeText
 import com.github.adriianh.cli.tui.util.TextFormatUtil.formatDuration
@@ -33,6 +34,7 @@ class MeloScreen(
     internal val loadMoreTracks: LoadMoreTracksUseCase,
     internal val getTrack: GetTrackUseCase,
     internal val getLyrics: GetLyricsUseCase,
+    internal val getSyncedLyrics: GetSyncedLyricsUseCase,
     internal val getSimilarTracks: GetSimilarTracksUseCase,
     // Favorites
     internal val getFavorites: GetFavoritesUseCase,
@@ -89,7 +91,7 @@ class MeloScreen(
             runner()?.runOnRenderThread {
                 val duration = state.nowPlaying?.durationMs ?: 0L
                 val progress = if (duration > 0) (elapsedMs.toDouble() / duration).coerceIn(0.0, 1.0) else 0.0
-                state = state.copy(progress = progress)
+                state = state.copy(progress = progress, nowPlayingPositionMs = elapsedMs)
                 mediaSession.updatePosition(elapsedMs)
             }
         },
@@ -158,6 +160,7 @@ class MeloScreen(
             "${MeloTheme.ICON_HOME} Home",
             "${MeloTheme.ICON_SEARCH} Search",
             "${MeloTheme.ICON_LIBRARY} Your Library",
+            "${MeloTheme.ICON_NOTE} Now Playing",
         )
         .highlightSymbol("${MeloTheme.ICON_ARROW} ")
         .highlightColor(MeloTheme.PRIMARY_COLOR)
@@ -262,17 +265,49 @@ class MeloScreen(
         }
     }
 
-    private fun renderMainContent(): Element = when (state.activeSection) {
-        SidebarSection.HOME    -> renderHomeScreen(
-            state, homeRecentList, homeFavoritesList,
-            onKeyEvent = ::handleHomeKey,
-        )
-        SidebarSection.SEARCH  -> renderSearchScreen(
-            state, resultList, lyricsArea, similarArea,
-            ::marqueeText, ::handleResultsKey, ::handleDetailKey,
-        )
-        SidebarSection.LIBRARY -> renderLibraryScreen(
-            state, favoritesList, playlistsList, playlistTracksList, ::handleLibraryKey,
-        )
+    private fun renderMainContent(): Element {
+        if (state.needsGraphicsClear) {
+            val pending = state.pendingSection
+            val targetSection = pending ?: state.activeSection
+            state = state.copy(
+                needsGraphicsClear = false,
+                activeSection = targetSection,
+                pendingSection = null,
+                artworkData = if (targetSection != SidebarSection.SEARCH) null else state.artworkData,
+            )
+            if (targetSection == SidebarSection.NOW_PLAYING) {
+                appRunner()?.focusManager()?.setFocus("now-playing-panel")
+            }
+            val targetContent = when (targetSection) {
+                SidebarSection.HOME    -> renderHomeScreen(
+                    state, homeRecentList, homeFavoritesList,
+                    onKeyEvent = ::handleHomeKey,
+                )
+                SidebarSection.SEARCH  -> renderSearchScreen(
+                    state, resultList, lyricsArea, similarArea,
+                    ::marqueeText, ::handleResultsKey, ::handleDetailKey,
+                )
+                SidebarSection.LIBRARY -> renderLibraryScreen(
+                    state, favoritesList, playlistsList, playlistTracksList, ::handleLibraryKey,
+                )
+                SidebarSection.NOW_PLAYING -> renderNowPlayingScreen(state, ::marqueeText, ::handlePlayerBarKey)
+            }
+            return stack(ClearGraphicsElement().fill(), targetContent)
+        }
+
+        return when (state.activeSection) {
+            SidebarSection.HOME    -> renderHomeScreen(
+                state, homeRecentList, homeFavoritesList,
+                onKeyEvent = ::handleHomeKey,
+            )
+            SidebarSection.SEARCH  -> renderSearchScreen(
+                state, resultList, lyricsArea, similarArea,
+                ::marqueeText, ::handleResultsKey, ::handleDetailKey,
+            )
+            SidebarSection.LIBRARY -> renderLibraryScreen(
+                state, favoritesList, playlistsList, playlistTracksList, ::handleLibraryKey,
+            )
+            SidebarSection.NOW_PLAYING -> renderNowPlayingScreen(state, ::marqueeText, ::handlePlayerBarKey)
+        }
     }
 }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloState.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloState.kt
@@ -1,5 +1,6 @@
 package com.github.adriianh.cli.tui
 
+import com.github.adriianh.cli.tui.util.LrcLine
 import com.github.adriianh.core.domain.model.HistoryEntry
 import com.github.adriianh.core.domain.model.Playlist
 import com.github.adriianh.core.domain.model.SimilarTrack
@@ -22,6 +23,7 @@ enum class SidebarSection {
     HOME,
     SEARCH,
     LIBRARY,
+    NOW_PLAYING,
 }
 
 /**
@@ -82,6 +84,7 @@ data class MeloState(
     val isLoadingLyrics: Boolean = false,
     val similarTracks: List<SimilarTrack> = emptyList(),
     val artworkData: ImageData? = null,
+    val nowPlayingArtwork: ImageData? = null,
 
     // Library
     val favorites: List<Track> = emptyList(),
@@ -125,4 +128,13 @@ data class MeloState(
 
     // Radio / auto-play
     val isRadioMode: Boolean = false,
+
+    // Now Playing screen — synced lyrics
+    val syncedLyrics: List<LrcLine> = emptyList(),
+    val isLoadingSyncedLyrics: Boolean = false,
+    val nowPlayingPositionMs: Long = 0L,
+
+    // Graphics
+    val needsGraphicsClear: Boolean = false,
+    val pendingSection: SidebarSection? = null,
 )

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/graphics/ClearGraphicsElement.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/graphics/ClearGraphicsElement.kt
@@ -19,6 +19,6 @@ class ClearGraphicsElement : StyledElement<ClearGraphicsElement>() {
 
     override fun constraint(): Constraint = Constraint.length(1)
 
-    override fun preferredSize(availableWidth: Int, availableHeight: Int, context: RenderContext): Size =
+    override fun preferredSize(availableWidth: Int, availableHeight: Int, context: RenderContext?): Size =
         Size.of(1, 1)
 }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenKeyHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenKeyHandlers.kt
@@ -116,7 +116,9 @@ internal fun MeloScreen.handleSidebarKey(event: KeyEvent): EventResult {
 
 internal fun MeloScreen.applySidebarSelection(): EventResult {
     val section = SidebarSection.entries.getOrNull(sidebarList.selected())
-    if (section != null) state = state.copy(activeSection = section)
+    if (section != null && section != state.activeSection) {
+        state = state.copy(needsGraphicsClear = true, pendingSection = section)
+    }
     return EventResult.HANDLED
 }
 

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenPlaybackHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenPlaybackHandlers.kt
@@ -1,6 +1,8 @@
 package com.github.adriianh.cli.tui.handler
 
 import  com.github.adriianh.cli.tui.*
+import com.github.adriianh.cli.tui.util.ArtworkRenderer
+import com.github.adriianh.cli.tui.util.LrcParser
 import com.github.adriianh.core.domain.model.Track
 import kotlinx.coroutines.*
 
@@ -20,10 +22,21 @@ internal fun MeloScreen.playTrack(track: Track) {
         isPlaying = false, isLoadingAudio = true,
         audioError = null, progress = 0.0, marqueeOffset = 0,
         queue = newQueue, queueIndex = newIndex, isRadioMode = newRadioMode,
+        syncedLyrics = emptyList(), isLoadingSyncedLyrics = true, nowPlayingPositionMs = 0L,
+        nowPlayingArtwork = null,
     )
     marqueeTick = 0
     audioPlayer.stop()
     loadTrackDetails(track.id, track)
+    scope.launch {
+        val artworkUrl = track.artworkUrl ?: getTrack(track.id)?.artworkUrl
+        val artwork = artworkUrl?.let { ArtworkRenderer.load(it) }
+        appRunner()?.runOnRenderThread {
+            if (state.nowPlaying?.id == track.id) {
+                state = state.copy(nowPlayingArtwork = artwork)
+            }
+        }
+    }
     scope.launch {
         recordPlay(track)
         val url = getStream(track)
@@ -35,6 +48,13 @@ internal fun MeloScreen.playTrack(track: Track) {
             state = state.copy(isPlaying = true, isLoadingAudio = false)
             audioPlayer.play(url)
             mediaSession.updateTrack(track, track.durationMs)
+        }
+        val lrc = getSyncedLyrics(track.artist, track.title)
+        appRunner()?.runOnRenderThread {
+            state = state.copy(
+                syncedLyrics = if (lrc != null) LrcParser.parse(lrc) else emptyList(),
+                isLoadingSyncedLyrics = false,
+            )
         }
     }
     checkIsFavorite(track.id)

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenSearchHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenSearchHandlers.kt
@@ -73,7 +73,9 @@ internal fun MeloScreen.loadTrackDetails(trackId: String, knownTrack: Track? = n
         val fullTrack = fullTrackDeferred.await() ?: knownTrack ?: return@launch
         val artworkData = fullTrack.artworkUrl?.let { ArtworkRenderer.load(it) }
         if (isActive) {
-            appRunner()?.runOnRenderThread { state = state.copy(selectedTrack = fullTrack, artworkData = artworkData) }
+            appRunner()?.runOnRenderThread {
+                state = state.copy(selectedTrack = fullTrack, artworkData = artworkData)
+            }
             val similar = similarDeferred.await()
             if (isActive) appRunner()?.runOnRenderThread { state = state.copy(similarTracks = similar) }
         }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/screen/NowPlayingScreen.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/screen/NowPlayingScreen.kt
@@ -1,0 +1,138 @@
+package com.github.adriianh.cli.tui.screen
+
+import com.github.adriianh.cli.tui.MeloState
+import com.github.adriianh.cli.tui.MeloTheme.BORDER_DEFAULT
+import com.github.adriianh.cli.tui.MeloTheme.ICON_NOTE
+import com.github.adriianh.cli.tui.MeloTheme.PRIMARY_COLOR
+import com.github.adriianh.cli.tui.MeloTheme.TEXT_DIM
+import com.github.adriianh.cli.tui.MeloTheme.TEXT_PRIMARY
+import com.github.adriianh.cli.tui.MeloTheme.TEXT_SECONDARY
+import com.github.adriianh.cli.tui.util.LrcParser
+import com.github.adriianh.core.domain.model.Track
+import dev.tamboui.image.Image
+import dev.tamboui.image.ImageScaling
+import dev.tamboui.layout.Constraint
+import dev.tamboui.layout.Flex
+import dev.tamboui.toolkit.Toolkit.*
+import dev.tamboui.toolkit.element.Element
+import dev.tamboui.toolkit.event.EventResult
+import dev.tamboui.tui.event.KeyEvent
+import dev.tamboui.widgets.block.Block
+import dev.tamboui.widgets.block.BorderType
+import dev.tamboui.widgets.block.Borders
+
+fun renderNowPlayingScreen(
+    state: MeloState,
+    marqueeText: (String, Int, Int) -> String,
+    onKeyEvent: (KeyEvent) -> EventResult
+): Element {
+    val track = state.nowPlaying ?: return renderNoTrackPlaying()
+
+    val artworkPanel = buildArtworkPanel(state)
+    val infoPanel    = buildInfoPanel(state, track, marqueeText)
+    val lyricsPanel  = buildLyricsPanel(state)
+
+    val leftColumn = dock()
+        .top(artworkPanel, Constraint.length(18))
+        .center(infoPanel)
+
+    val content = dock()
+        .left(leftColumn, Constraint.percentage(40))
+        .center(lyricsPanel)
+
+    return panel(content)
+        .borderless()
+        .focusable()
+        .id("now-playing-panel")
+        .onKeyEvent(onKeyEvent)
+}
+
+private fun renderNoTrackPlaying(): Element = panel(
+    column(
+        spacer(),
+        text("$ICON_NOTE  Nothing is playing").fg(TEXT_SECONDARY).centered(),
+        text("Search for a song and press Enter to start").fg(TEXT_DIM).centered(),
+        spacer(),
+    )
+).title("Now Playing")
+    .rounded()
+    .borderColor(BORDER_DEFAULT)
+
+private fun buildArtworkPanel(state: MeloState): Element =
+    if (state.nowPlayingArtwork != null) {
+        widget(
+            Image.builder()
+                .data(state.nowPlayingArtwork)
+                .scaling(ImageScaling.FIT)
+                .block(
+                    Block.builder()
+                        .borders(Borders.ALL)
+                        .borderType(BorderType.ROUNDED)
+                        .build()
+                )
+                .build()
+        )
+    } else {
+        panel(text("[ No Artwork ]").dim().centered()).rounded()
+    }
+
+private fun buildInfoPanel(
+    state: MeloState,
+    track: Track,
+    marqueeText: (String, Int, Int) -> String,
+): Element = panel(
+    column(
+        spacer(),
+        text(marqueeText(track.title, state.marqueeOffset, 28)).bold().fg(TEXT_PRIMARY).centered(),
+        text(track.artist).fg(TEXT_SECONDARY).centered(),
+        text(track.album).fg(TEXT_DIM).centered(),
+        spacer(),
+    ).flex(Flex.CENTER)
+).rounded().borderColor(BORDER_DEFAULT)
+
+private fun buildLyricsPanel(state: MeloState): Element {
+    val title = "Lyrics"
+
+    if (state.isLoadingSyncedLyrics) {
+        return panel(
+            column(spacer(), text("  Loading lyrics...").dim().centered(), spacer())
+        ).title(title).rounded().borderColor(BORDER_DEFAULT)
+    }
+
+    val lines = state.syncedLyrics
+    if (lines.isEmpty()) {
+        return panel(
+            column(
+                spacer(),
+                text("  No synced lyrics available").fg(TEXT_SECONDARY).centered(),
+                spacer())
+        ).title(title).rounded().borderColor(BORDER_DEFAULT)
+    }
+
+    val currentIndex = LrcParser.currentLineIndex(lines, state.nowPlayingPositionMs)
+
+    val windowSize = 20
+    val half = windowSize / 2
+    val start = (currentIndex - half).coerceAtLeast(0)
+    val end   = (start + windowSize).coerceAtMost(lines.size)
+    val visibleLines = lines.subList(start, end)
+    val visibleCurrentIndex = currentIndex - start
+
+    val lineElements = visibleLines.mapIndexed { i, lrcLine ->
+        val isCurrent = i == visibleCurrentIndex
+        val displayText = lrcLine.text.ifBlank { " " }
+        val t = text(displayText)
+        when {
+            isCurrent -> t.bold().fg(PRIMARY_COLOR).centered()
+            i < visibleCurrentIndex -> t.fg(TEXT_DIM).centered()
+            else -> t.fg(TEXT_SECONDARY).centered()
+        }
+    }
+
+    return panel(
+        column(
+            spacer(),
+            *lineElements.toTypedArray(),
+            spacer())
+    ).title(title).rounded().borderColor(BORDER_DEFAULT)
+}

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/util/LrcParser.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/util/LrcParser.kt
@@ -1,0 +1,55 @@
+package com.github.adriianh.cli.tui.util
+
+/**
+ * A single line of a synced (LRC) lyrics file.
+ * [timeMs] is the timestamp in milliseconds, [text] is the lyric line.
+ */
+data class LrcLine(val timeMs: Long, val text: String)
+
+/**
+ * Parses an LRC-formatted string into a list of [LrcLine].
+ *
+ * LRC format:
+ *   [mm:ss.xx] lyric text
+ *   [mm:ss.xxx] lyric text   (milliseconds variant)
+ *
+ * Lines without a valid timestamp are discarded.
+ * The result is sorted by time ascending.
+ */
+object LrcParser {
+
+    private val LRC_LINE_REGEX = Regex("""^\[(\d{2}):(\d{2})\.(\d{2,3})](.*)\s*$""")
+
+    fun parse(lrc: String): List<LrcLine> {
+        return lrc.lines()
+            .mapNotNull { line -> parseLine(line.trim()) }
+            .sortedBy { it.timeMs }
+    }
+
+    private fun parseLine(line: String): LrcLine? {
+        val match = LRC_LINE_REGEX.matchEntire(line) ?: return null
+        val (mm, ss, cs, text) = match.destructured
+        val minutes = mm.toLongOrNull() ?: return null
+        val seconds = ss.toLongOrNull() ?: return null
+        val fractionMs = when (cs.length) {
+            2 -> cs.toLong() * 10
+            3 -> cs.toLong()
+            else -> 0L
+        }
+        val timeMs = minutes * 60_000L + seconds * 1_000L + fractionMs
+        return LrcLine(timeMs, text.trim())
+    }
+
+    /**
+     * Returns the index of the current line given [positionMs].
+     * Returns -1 if [lines] is empty or playback hasn't reached the first line yet.
+     */
+    fun currentLineIndex(lines: List<LrcLine>, positionMs: Long): Int {
+        if (lines.isEmpty()) return -1
+        var index = -1
+        for (i in lines.indices) {
+            if (lines[i].timeMs <= positionMs) index = i else break
+        }
+        return index
+    }
+}

--- a/core/src/main/kotlin/com/github/adriianh/core/domain/repository/LyricsRepository.kt
+++ b/core/src/main/kotlin/com/github/adriianh/core/domain/repository/LyricsRepository.kt
@@ -2,4 +2,5 @@ package com.github.adriianh.core.domain.repository
 
 interface LyricsRepository {
     suspend fun getLyrics(artist: String, title: String): String?
+    suspend fun getSyncedLyrics(artist: String, title: String): String?
 }

--- a/core/src/main/kotlin/com/github/adriianh/core/domain/usecase/GetSyncedLyricsUseCase.kt
+++ b/core/src/main/kotlin/com/github/adriianh/core/domain/usecase/GetSyncedLyricsUseCase.kt
@@ -1,0 +1,12 @@
+package com.github.adriianh.core.domain.usecase
+
+import com.github.adriianh.core.domain.repository.LyricsRepository
+
+class GetSyncedLyricsUseCase(
+    private val repository: LyricsRepository
+) {
+    suspend operator fun invoke(artist: String, title: String): String? {
+        if (artist.isBlank() || title.isBlank()) return null
+        return repository.getSyncedLyrics(artist, title)
+    }
+}

--- a/data/src/main/kotlin/com/github/adriianh/data/remote/lyrics/LyricsApiClient.kt
+++ b/data/src/main/kotlin/com/github/adriianh/data/remote/lyrics/LyricsApiClient.kt
@@ -12,14 +12,17 @@ class LyricsApiClient(
     private val httpClient: HttpClient
 ) {
 
-    suspend fun getLyrics(artist: String, title: String): String? {
+    /**
+     * Fetches both plain and synced lyrics in a single request.
+     * Returns null if the request fails or the track is not found.
+     */
+    suspend fun getLyricsResponse(artist: String, title: String): LyricsResponse? {
         return try {
-            val response = httpClient.get("https://lrclib.net/api/get") {
+            httpClient.get("https://lrclib.net/api/get") {
                 parameter("artist_name", artist)
                 parameter("track_name", title)
-            }
-            response.body<LyricsResponse>().plainLyrics
-        } catch (e: Exception) {
+            }.body<LyricsResponse>()
+        } catch (_: Exception) {
             null
         }
     }

--- a/data/src/main/kotlin/com/github/adriianh/data/remote/lyrics/LyricsDto.kt
+++ b/data/src/main/kotlin/com/github/adriianh/data/remote/lyrics/LyricsDto.kt
@@ -5,5 +5,6 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class LyricsResponse(
-    @SerialName("plainLyrics") val plainLyrics: String? = null
+    @SerialName("plainLyrics") val plainLyrics: String? = null,
+    @SerialName("syncedLyrics") val syncedLyrics: String? = null,
 )

--- a/data/src/main/kotlin/com/github/adriianh/data/repository/LyricsRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/github/adriianh/data/repository/LyricsRepositoryImpl.kt
@@ -8,7 +8,7 @@ class LyricsRepositoryImpl(
 ) : LyricsRepository {
 
     override suspend fun getLyrics(artist: String, title: String): String? {
-        val raw = lyricsApiClient.getLyrics(artist, title) ?: return null
+        val raw = lyricsApiClient.getLyricsResponse(artist, title)?.plainLyrics ?: return null
         return if (raw.startsWith("Paroles") || raw.startsWith("Lyrics of")) {
             val firstNewline = raw.indexOf('\n')
             if (firstNewline != -1) raw.substring(firstNewline).trimStart() else raw
@@ -16,4 +16,7 @@ class LyricsRepositoryImpl(
             raw
         }
     }
+
+    override suspend fun getSyncedLyrics(artist: String, title: String): String? =
+        lyricsApiClient.getLyricsResponse(artist, title)?.syncedLyrics
 }


### PR DESCRIPTION
## What
Adds a dedicated **Now Playing** screen accessible from the sidebar, showing the current track's artwork, metadata, and real-time scrolling synced lyrics (LRC format).

## Why
The player bar gives minimal context about what's playing. This screen gives users a full-screen view with synchronized lyrics that follow playback position, making Melo feel like a complete music player.

## How
- `NowPlayingScreen` is split into three panels: artwork, track info (title/artist/album), and a scrolling lyrics panel with the current line highlighted
- `LrcParser` handles parsing `.lrc` timestamps and finding the current line index based on playback position (ms)
- `GetSyncedLyricsUseCase` fetches synced lyrics; `LyricsApiClient` was consolidated into a single endpoint shared by both plain and synced lyrics responses
- Playback position (`nowPlayingPositionMs`) is already tracked via `AudioPlayer.onProgress` and used to scroll the lyrics window in real time
- Fixed artwork bleed-through on screen transitions: the transition frame now renders the **target** screen (not the source) over `ClearGraphicsElement`, and `artworkData` is reset when navigating away from Search

## Testing
- Manually tested navigation to Now Playing from all other screens
- Verified synced lyrics scroll and highlight correctly during playback
- Verified artwork from SearchScreen no longer persists when switching to Now Playing or other screens