### PR TITLE
perf(playback): optimize pre-fetching and manual queue tracking

### DIFF
--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloState.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloState.kt
@@ -105,6 +105,7 @@ data class PlayerState(
     val volume: Int = 75,
     val isRadioMode: Boolean = false,
     val isLoadingMoreRadio: Boolean = false,
+    val userQueueCount: Int = 0,
     val syncedLyrics: List<LrcLine> = emptyList(),
     val isLoadingSyncedLyrics: Boolean = false,
     val nowPlayingPositionMs: Long = 0L,

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/PlaybackHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/PlaybackHandlers.kt
@@ -22,7 +22,12 @@ import kotlinx.coroutines.launch
 internal fun MeloScreen.playTrack(track: Track) {
     if (!state.isPlayable(track)) return
 
-    val existingIndex = state.player.queue.indexOfFirst { it.id == track.id }
+    val currentIndex = state.player.queueIndex
+    val isCurrentTrack =
+        currentIndex in state.player.queue.indices && state.player.queue[currentIndex].id == track.id
+    val existingIndex =
+        if (isCurrentTrack) currentIndex else state.player.queue.indexOfFirst { it.id == track.id }
+
     val (newQueue, newIndex, newRadioMode) = when {
         existingIndex >= 0 -> Triple(state.player.queue, existingIndex, state.player.isRadioMode)
         else -> Triple(listOf(track), 0, true)

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/PlaybackHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/PlaybackHandlers.kt
@@ -8,17 +8,20 @@ import com.github.adriianh.cli.tui.handler.onTrackStarted
 import com.github.adriianh.cli.tui.handler.search.loadNowPlayingMetadata
 import com.github.adriianh.cli.tui.isPlayable
 import com.github.adriianh.cli.tui.util.LrcParser
+import com.github.adriianh.core.domain.model.DownloadStatus
 import com.github.adriianh.core.domain.model.MeloAction
 import com.github.adriianh.core.domain.model.Track
 import dev.tamboui.toolkit.event.EventResult
 import dev.tamboui.tui.bindings.Actions
 import dev.tamboui.tui.event.KeyCode
 import dev.tamboui.tui.event.KeyEvent
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 internal fun MeloScreen.playTrack(track: Track) {
     if (!state.isPlayable(track)) return
+
     val existingIndex = state.player.queue.indexOfFirst { it.id == track.id }
     val (newQueue, newIndex, newRadioMode) = when {
         existingIndex >= 0 -> Triple(state.player.queue, existingIndex, state.player.isRadioMode)
@@ -35,24 +38,39 @@ internal fun MeloScreen.playTrack(track: Track) {
             progress = 0.0, marqueeOffset = 0,
         )
     )
+
     marqueeTick = 0
     scrobbleSubmitted = false
     playRecorded = false
     trackStartedAt = System.currentTimeMillis()
     audioPlayer.stop()
+
     if (state.player.isRadioMode && !state.player.isLoadingMoreRadio && state.player.queueIndex >= state.player.queue.size - 3) {
         loadMoreRadioTracks()
     }
     loadNowPlayingMetadata(track)
+
     resolveStreamJob?.cancel()
     resolveStreamJob = scope.launch {
+        val queue = state.player.queue
+        val nextTracks =
+            (1..2).mapNotNull { offset -> queue.getOrNull(state.player.queueIndex + offset) }
+
         markTrackAccessed(track.id)
+
         if (settingsViewState.currentSettings.autoDownload) {
-            val queue = state.player.queue
-            val currentIndex = state.player.queueIndex
-            (1..2).mapNotNull { offset -> queue.getOrNull(currentIndex + offset) }
-                .forEach { nextTrack -> launch { downloadTrack(nextTrack) } }
+            nextTracks.forEach { nextTrack -> launch(Dispatchers.IO) { downloadTrack(nextTrack) } }
         }
+
+        nextTracks
+            .filter { it.sourceId != null }
+            .filter { offlineRepository.getOfflineTrack(it.id)?.downloadStatus != DownloadStatus.COMPLETED }
+            .forEach { nextTrack ->
+                launch(Dispatchers.IO) {
+                    getStream(nextTrack)
+                }
+            }
+
         var url: String? = null
         var attempts = 0
         val maxAttempts = 3
@@ -81,6 +99,7 @@ internal fun MeloScreen.playTrack(track: Track) {
             }
             onTrackStarted(track)
         }
+
         val lrc = getSyncedLyrics(track.artist, track.title)
         appRunner()?.runOnRenderThread {
             state = state.copy(
@@ -91,6 +110,7 @@ internal fun MeloScreen.playTrack(track: Track) {
             )
         }
     }
+
     checkIsFavorite(track.id)
 }
 

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/PlaybackHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/PlaybackHandlers.kt
@@ -73,7 +73,6 @@ internal fun MeloScreen.playTrack(track: Track) {
         }
 
         nextTracks
-            .filter { it.sourceId != null }
             .filter { offlineRepository.getOfflineTrack(it.id)?.downloadStatus != DownloadStatus.COMPLETED }
             .forEach { nextTrack ->
                 launch(Dispatchers.IO) {

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/PlaybackHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/PlaybackHandlers.kt
@@ -28,16 +28,21 @@ internal fun MeloScreen.playTrack(track: Track) {
     val existingIndex =
         if (isCurrentTrack) currentIndex else state.player.queue.indexOfFirst { it.id == track.id }
 
-    val (newQueue, newIndex, newRadioMode) = when {
-        existingIndex >= 0 -> Triple(state.player.queue, existingIndex, state.player.isRadioMode)
-        else -> Triple(listOf(track), 0, true)
+    val (newQueue, newIndex, newRadioMode, newUserQueueCount) = when {
+        existingIndex >= 0 -> listOf(state.player.queue, existingIndex, state.player.isRadioMode, state.player.userQueueCount)
+        else -> listOf(listOf(track), 0, true, 0)
     }
+
+    @Suppress("UNCHECKED_CAST")
     state = state.copy(
         player = state.player.copy(
             nowPlaying = track,
             isPlaying = false, isLoadingAudio = true,
             audioError = null,
-            queue = newQueue, queueIndex = newIndex, isRadioMode = newRadioMode,
+            queue = newQueue as List<Track>,
+            queueIndex = newIndex as Int,
+            isRadioMode = newRadioMode as Boolean,
+            userQueueCount = newUserQueueCount as Int,
             syncedLyrics = emptyList(), isLoadingSyncedLyrics = true, nowPlayingPositionMs = 0L,
             nowPlayingArtwork = null,
             progress = 0.0, marqueeOffset = 0,
@@ -195,6 +200,19 @@ internal fun MeloScreen.seekForward() {
             next
         }
     }
+
+    val previousIndex = state.player.queueIndex
+    val diff = nextIndex - previousIndex
+    val newUserQueueCount = if (diff == 1 && state.player.userQueueCount > 0) {
+        state.player.userQueueCount - 1
+    } else if (diff != 0) {
+        0
+    } else {
+        state.player.userQueueCount
+    }
+
+    state = state.copy(player = state.player.copy(userQueueCount = newUserQueueCount))
+
     playFromQueue(nextIndex)
 }
 
@@ -211,7 +229,8 @@ internal fun MeloScreen.playList(tracks: List<Track>, startIndex: Int) {
         player = state.player.copy(
             queue = playableTracks,
             queueIndex = -1,
-            isRadioMode = false
+            isRadioMode = false,
+            userQueueCount = 0
         )
     )
     playFromQueue(newStartIndex)

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/QueueHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/QueueHandlers.kt
@@ -12,10 +12,27 @@ import dev.tamboui.tui.event.KeyEvent
 
 internal fun MeloScreen.addToQueue(track: Track) {
     if (!state.isPlayable(track)) return
-    val newQueue = state.player.queue + track
-    val newIndex = if (state.player.queueIndex < 0 && state.player.nowPlaying == null) 0 else state.player.queueIndex
+
+    val currentQueue = state.player.queue.toMutableList()
+    val newManualCount = state.player.userQueueCount + 1
+
+    val insertIndex = if (state.player.queueIndex < 0) 0 else minOf(
+        state.player.queueIndex + newManualCount,
+        currentQueue.size
+    )
+    currentQueue.add(insertIndex, track)
+
+    val newIndex =
+        if (state.player.queueIndex < 0 && state.player.nowPlaying == null) 0 else state.player.queueIndex
     val newRadioMode = state.player.isRadioMode && state.player.nowPlaying != null
-    state = state.copy(player = state.player.copy(queue = newQueue, queueIndex = newIndex, isRadioMode = newRadioMode))
+    state = state.copy(
+        player = state.player.copy(
+            queue = currentQueue,
+            queueIndex = newIndex,
+            isRadioMode = newRadioMode,
+            userQueueCount = newManualCount
+        )
+    )
     if (state.player.nowPlaying == null && !state.player.isLoadingAudio) playFromQueue(0)
 }
 
@@ -29,11 +46,22 @@ internal fun MeloScreen.removeFromQueue(index: Int) {
         index == state.player.queueIndex -> minOf(index, newQueue.lastIndex)
         else -> state.player.queueIndex
     }
+
+    val manualStart = state.player.queueIndex + 1
+    val manualEnd = state.player.queueIndex + state.player.userQueueCount
+    val newUserQueueCount =
+        if (index in manualStart..manualEnd && state.player.userQueueCount > 0) {
+            state.player.userQueueCount - 1
+        } else {
+            state.player.userQueueCount
+        }
+
     state = state.copy(
         player = state.player.copy(
             queue = newQueue,
             queueIndex = newIndex,
             queueCursor = minOf(state.player.queueCursor, (newQueue.size - 1).coerceAtLeast(0)),
+            userQueueCount = newUserQueueCount
         )
     )
     if (removingPlaying) {
@@ -43,7 +71,8 @@ internal fun MeloScreen.removeFromQueue(index: Int) {
                 nowPlaying = null,
                 isPlaying = false,
                 isRadioMode = false,
-                progress = 0.0
+                progress = 0.0,
+                userQueueCount = 0
             )
         )
         else playFromQueue(if (newIndex >= 0 && newIndex < newQueue.size) newIndex else 0)
@@ -56,7 +85,7 @@ internal fun MeloScreen.clearQueue() {
         player = state.player.copy(
             queue = emptyList(), queueIndex = -1, queueCursor = 0,
             nowPlaying = null, isPlaying = false, isRadioMode = false,
-            progress = 0.0,
+            progress = 0.0, userQueueCount = 0
         ),
     )
 }
@@ -88,7 +117,14 @@ internal fun MeloScreen.handleQueueKey(event: KeyEvent): EventResult {
 
         event.matches(Actions.MOVE_UP) -> {
             if (!isFocused) return EventResult.UNHANDLED
-            state = state.copy(player = state.player.copy(queueCursor = maxOf(0, state.player.queueCursor - 1)))
+            state = state.copy(
+                player = state.player.copy(
+                    queueCursor = maxOf(
+                        0,
+                        state.player.queueCursor - 1
+                    )
+                )
+            )
             return EventResult.HANDLED
         }
 

--- a/data/src/main/kotlin/com/github/adriianh/data/provider/audio/YtDlpAudioProvider.kt
+++ b/data/src/main/kotlin/com/github/adriianh/data/provider/audio/YtDlpAudioProvider.kt
@@ -27,6 +27,7 @@ class YtDlpAudioProvider(
 
     private val ytDlpBin: String by lazy { YtDlpBootstrap.resolve() }
     private val streamUrlCache = ConcurrentHashMap<String, String>()
+    private val sourceIdCache = ConcurrentHashMap<String, String>()
 
     /**
      * Extracts the exact expiration time from a YouTube stream URL's "expire=" query parameter.
@@ -43,8 +44,16 @@ class YtDlpAudioProvider(
      * Uses Piped's `music_songs` filter to find the correct YouTube Music video ID
      * for the given track. Returns the ID (e.g. `"4NRXx6U8ABQ"`) or null on failure.
      */
-    override suspend fun getSourceId(artist: String, title: String, durationMs: Long): String? =
-        pipedApiClient.search(title, title, artist, durationMs)
+    override suspend fun getSourceId(artist: String, title: String, durationMs: Long): String? {
+        val cacheKey = "$artist|$title|$durationMs"
+        sourceIdCache[cacheKey]?.let { return it }
+
+        val id = pipedApiClient.search(title, title, artist, durationMs)
+        if (id != null) {
+            sourceIdCache[cacheKey] = id
+        }
+        return id
+    }
 
     /**
      * Resolves a direct audio-stream URL for the given YouTube video ID using a

--- a/data/src/main/kotlin/com/github/adriianh/data/provider/audio/YtDlpAudioProvider.kt
+++ b/data/src/main/kotlin/com/github/adriianh/data/provider/audio/YtDlpAudioProvider.kt
@@ -26,8 +26,18 @@ class YtDlpAudioProvider(
 ) : AudioProvider {
 
     private val ytDlpBin: String by lazy { YtDlpBootstrap.resolve() }
-    private val streamUrlCache = ConcurrentHashMap<String, Pair<String, Long>>()
-    private val cacheExpiryMs = 6 * 60 * 60 * 1000L
+    private val streamUrlCache = ConcurrentHashMap<String, String>()
+
+    /**
+     * Extracts the exact expiration time from a YouTube stream URL's "expire=" query parameter.
+     * Returns null if not found.
+     */
+    private fun getUrlExpiryTimeMs(url: String): Long? {
+        // e.g. ...&expire=1711099234&...
+        val regex = Regex("""[?&]expire=(\d+)""")
+        val match = regex.find(url) ?: return null
+        return match.groupValues[1].toLongOrNull()?.times(1000L)
+    }
 
     /**
      * Uses Piped's `music_songs` filter to find the correct YouTube Music video ID
@@ -41,8 +51,9 @@ class YtDlpAudioProvider(
      * single yt-dlp subprocess (~2-4 s). Returns null on failure.
      */
     override suspend fun getStreamUrl(sourceId: String): String? {
-        streamUrlCache[sourceId]?.let { (url, timestamp) ->
-            if (System.currentTimeMillis() - timestamp < cacheExpiryMs) {
+        streamUrlCache[sourceId]?.let { url ->
+            val expiryTimeMs = getUrlExpiryTimeMs(url)
+            if (expiryTimeMs == null || System.currentTimeMillis() < (expiryTimeMs - 5 * 60 * 1000L)) {
                 return url
             }
             streamUrlCache.remove(sourceId)
@@ -66,7 +77,7 @@ class YtDlpAudioProvider(
                 ).lines().firstOrNull { it.startsWith("http") }
 
                 streamUrl?.also {
-                    streamUrlCache[sourceId] = Pair(it, System.currentTimeMillis())
+                    streamUrlCache[sourceId] = it
                 }
             } catch (_: Exception) {
                 null

--- a/data/src/main/kotlin/com/github/adriianh/data/provider/audio/YtDlpAudioProvider.kt
+++ b/data/src/main/kotlin/com/github/adriianh/data/provider/audio/YtDlpAudioProvider.kt
@@ -5,6 +5,7 @@ import com.github.adriianh.data.remote.piped.PipedApiClient
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 
 /**
  * AudioProvider that combines two backends for best results:
@@ -25,6 +26,8 @@ class YtDlpAudioProvider(
 ) : AudioProvider {
 
     private val ytDlpBin: String by lazy { YtDlpBootstrap.resolve() }
+    private val streamUrlCache = ConcurrentHashMap<String, Pair<String, Long>>()
+    private val cacheExpiryMs = 6 * 60 * 60 * 1000L
 
     /**
      * Uses Piped's `music_songs` filter to find the correct YouTube Music video ID
@@ -37,11 +40,18 @@ class YtDlpAudioProvider(
      * Resolves a direct audio-stream URL for the given YouTube video ID using a
      * single yt-dlp subprocess (~2-4 s). Returns null on failure.
      */
-    override suspend fun getStreamUrl(sourceId: String): String? =
-        withContext(Dispatchers.IO) {
+    override suspend fun getStreamUrl(sourceId: String): String? {
+        streamUrlCache[sourceId]?.let { (url, timestamp) ->
+            if (System.currentTimeMillis() - timestamp < cacheExpiryMs) {
+                return url
+            }
+            streamUrlCache.remove(sourceId)
+        }
+
+        return withContext(Dispatchers.IO) {
             try {
                 val url = "https://www.youtube.com/watch?v=$sourceId"
-                runYtDlp(
+                val streamUrl = runYtDlp(
                     "--quiet",
                     "--no-warnings",
                     "--no-playlist",
@@ -54,10 +64,15 @@ class YtDlpAudioProvider(
                     "--get-url",
                     url
                 ).lines().firstOrNull { it.startsWith("http") }
+
+                streamUrl?.also {
+                    streamUrlCache[sourceId] = Pair(it, System.currentTimeMillis())
+                }
             } catch (_: Exception) {
                 null
             }
         }
+    }
 
     /**
      * Downloads the audio for the given YouTube video ID using yt-dlp with the specified

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Mar 01 13:23:13 CST 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What
Fixes radio mode overriding manually queued tracks by tracking `userQueueCount` and inserting manual additions consecutively before any automatically generated radio tracks. It also eliminates playback transition lag by properly pre-fetching tracks from external sources (Spotify/Last.fm integration) and parses explicit expiration dates on cached YouTube URLs with a 5-minute safety buffer to prevent sudden streaming interruptions.

## Why
When adding multiple songs sequentially to the queue, radio mode would push the user's picks to the very bottom, losing their order. Additionally, under poor network conditions, the default 6-hour URL cache and synchronous fetch operations during song transitions produced long, frustrating empty gaps in audio.

## Testing
- Manually tested sequential queue additions alongside an active radio mode to ensure priority.
- Verified that pre-fetching correctly initiates ahead of time on tracks originally missing a `sourceId` (querying Piped synchronously before the track ends).
- Validated cache expiry behavior.
