### PR TITLE
fix(tui): allow non-ASCII characters in search and playlist inputs

### DIFF
--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenPlaylistHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenPlaylistHandlers.kt
@@ -112,8 +112,11 @@ internal fun MeloScreen.handlePlaylistInput(event: KeyEvent): EventResult {
             state = state.copy(playlistInteraction = interaction.copy(playlistInput = interaction.playlistInput.dropLast(1)))
             return EventResult.HANDLED
         }
-        event.code() == KeyCode.CHAR -> {
-            state = state.copy(playlistInteraction = interaction.copy(playlistInput = interaction.playlistInput + event.character()))
+        event.code() == KeyCode.CHAR && !event.modifiers().ctrl() && !event.modifiers().alt() -> {
+            val c = event.character()
+            if (c >= ' ') {
+                state = state.copy(playlistInteraction = interaction.copy(playlistInput = interaction.playlistInput + c))
+            }
             return EventResult.HANDLED
         }
     }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/search/SearchHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/search/SearchHandlers.kt
@@ -112,6 +112,14 @@ internal fun MeloScreen.focusResults() {
 }
 
 internal fun MeloScreen.handleSearchBarKey(event: KeyEvent): EventResult {
+    if (event.code() == KeyCode.CHAR && !event.modifiers().ctrl() && !event.modifiers().alt()) {
+        val c = event.character()
+        if (c >= '\u007F') {
+            searchInputState.insert(c)
+            return EventResult.HANDLED
+        }
+    }
+
     val s = state.screen as? ScreenState.Search ?: return EventResult.UNHANDLED
     if (s.results.isNotEmpty() &&
         (event.matches(Actions.MOVE_DOWN) || event.matches(Actions.MOVE_UP))


### PR DESCRIPTION
#### What
Allows special characters (like `ñ` and accented vowels) to be typed correctly in the search bar and playlist input dialog.

#### Why
The underlying UI framework restricts text input fields to ASCII characters by default, preventing users from typing local characters.

#### Testing
- Verified entering non-ASCII characters in both the search bar and the playlist creation/rename input fields.