### PR TITLE
feat(tui): add vim-style command bar overlay

### DIFF
--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
@@ -6,9 +6,8 @@ import com.github.adriianh.cli.tui.component.PlaylistPickerOverlay
 import com.github.adriianh.cli.tui.component.QueueOverlay
 import com.github.adriianh.cli.tui.component.SearchSuggestionsOverlay
 import com.github.adriianh.cli.tui.component.SettingsOverlay
-import com.github.adriianh.cli.tui.component.TrackOptionsOverlay
-import com.github.adriianh.cli.tui.component.CommandBarOverlay
 import com.github.adriianh.cli.tui.component.SettingsViewState
+import com.github.adriianh.cli.tui.component.TrackOptionsOverlay
 import com.github.adriianh.cli.tui.component.screen.deleteDownloadedTrackAction
 import com.github.adriianh.cli.tui.component.screen.downloadTrackAction
 import com.github.adriianh.cli.tui.component.screen.handleAudioError
@@ -354,7 +353,6 @@ class MeloScreen(
     internal val searchSuggestionsOverlay = SearchSuggestionsOverlay { state }
     internal val playlistPickerOverlay = PlaylistPickerOverlay { state }
     internal val queueOverlay = QueueOverlay({ state }, queueList, ::handleQueueKey)
-    internal val commandBarOverlay = CommandBarOverlay { state }
     internal val settingsOverlay = SettingsOverlay(
         { state },
         { settingsViewState },

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
@@ -6,8 +6,9 @@ import com.github.adriianh.cli.tui.component.PlaylistPickerOverlay
 import com.github.adriianh.cli.tui.component.QueueOverlay
 import com.github.adriianh.cli.tui.component.SearchSuggestionsOverlay
 import com.github.adriianh.cli.tui.component.SettingsOverlay
-import com.github.adriianh.cli.tui.component.SettingsViewState
 import com.github.adriianh.cli.tui.component.TrackOptionsOverlay
+import com.github.adriianh.cli.tui.component.CommandBarOverlay
+import com.github.adriianh.cli.tui.component.SettingsViewState
 import com.github.adriianh.cli.tui.component.screen.deleteDownloadedTrackAction
 import com.github.adriianh.cli.tui.component.screen.downloadTrackAction
 import com.github.adriianh.cli.tui.component.screen.handleAudioError
@@ -353,6 +354,7 @@ class MeloScreen(
     internal val searchSuggestionsOverlay = SearchSuggestionsOverlay { state }
     internal val playlistPickerOverlay = PlaylistPickerOverlay { state }
     internal val queueOverlay = QueueOverlay({ state }, queueList, ::handleQueueKey)
+    internal val commandBarOverlay = CommandBarOverlay { state }
     internal val settingsOverlay = SettingsOverlay(
         { state },
         { settingsViewState },

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
@@ -1,5 +1,6 @@
 package com.github.adriianh.cli.tui
 
+import com.github.adriianh.cli.tui.component.CommandBarSuggestionsOverlay
 import com.github.adriianh.cli.tui.component.DirectoryPickerOverlay
 import com.github.adriianh.cli.tui.component.PlaylistInputOverlay
 import com.github.adriianh.cli.tui.component.PlaylistPickerOverlay
@@ -365,6 +366,7 @@ class MeloScreen(
         ::handleSettingsKey
     )
     internal val trackOptionsOverlay = TrackOptionsOverlay({ state }, ::handleTrackOptionsKey)
+    internal val commandBarSuggestionsOverlay = CommandBarSuggestionsOverlay { state }
 
     override fun configure(): TuiConfig = TuiConfig.builder().mouseCapture(true).build()
 

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloState.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloState.kt
@@ -249,7 +249,8 @@ data class CommandBarState(
     val errorMessage: String? = null,
     val history: List<String> = emptyList(),
     val historyIndex: Int = -1,
-    val cursorPosition: Int = 0
+    val cursorPosition: Int = 0,
+    val previousFocusId: String? = null
 )
 
 /**

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloState.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloState.kt
@@ -250,7 +250,9 @@ data class CommandBarState(
     val history: List<String> = emptyList(),
     val historyIndex: Int = -1,
     val cursorPosition: Int = 0,
-    val previousFocusId: String? = null
+    val previousFocusId: String? = null,
+    val suggestions: List<String> = emptyList(),
+    val selectedSuggestionIndex: Int? = null
 )
 
 /**

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloState.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloState.kt
@@ -241,6 +241,18 @@ data class TrackOptionsMenuState(
 )
 
 /**
+ * Global UI/System flags
+ */
+data class CommandBarState(
+    val isVisible: Boolean = false,
+    val input: String = "",
+    val errorMessage: String? = null,
+    val history: List<String> = emptyList(),
+    val historyIndex: Int = -1,
+    val cursorPosition: Int = 0
+)
+
+/**
  * Global persistent collections.
  */
 data class CollectionsState(
@@ -271,6 +283,9 @@ data class MeloState(
 
     // Global Track options (context menu)
     val trackOptions: TrackOptionsMenuState = TrackOptionsMenuState(),
+
+    // Global command bar
+    val commandBar: CommandBarState = CommandBarState(),
 
     // Global UI/System flags
     val isSettingsVisible: Boolean = false,

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/CommandBarOverlay.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/CommandBarOverlay.kt
@@ -3,53 +3,35 @@ package com.github.adriianh.cli.tui.component
 import com.github.adriianh.cli.tui.MeloState
 import com.github.adriianh.cli.tui.MeloTheme.PRIMARY_COLOR
 import com.github.adriianh.cli.tui.MeloTheme.TEXT_PRIMARY
-import dev.tamboui.layout.Constraint
-import dev.tamboui.layout.Rect
 import dev.tamboui.style.Color
-import dev.tamboui.terminal.Frame
-import dev.tamboui.toolkit.Toolkit.*
+import dev.tamboui.toolkit.Toolkit.row
+import dev.tamboui.toolkit.Toolkit.spacer
+import dev.tamboui.toolkit.Toolkit.text
 import dev.tamboui.toolkit.element.Element
-import dev.tamboui.toolkit.element.RenderContext
-import dev.tamboui.toolkit.element.Size
 import dev.tamboui.toolkit.event.EventResult
 import dev.tamboui.tui.event.KeyEvent
 
-class CommandBarOverlay(private val stateProvider: () -> MeloState) : Element {
-    override fun render(frame: Frame, area: Rect, context: RenderContext) {
-        val state = stateProvider()
-        if (!state.commandBar.isVisible) return
-
-        val overlayH = 1
-        val overlayW = area.width()
-        val overlayX = area.x()
-        val overlayY = area.y() + area.height() - overlayH
-        val overlayArea = Rect(overlayX, overlayY, overlayW, overlayH)
-        frame.buffer().clear(overlayArea)
-        val content = if (state.commandBar.errorMessage != null) {
-            row(
-                text(" ").bg(Color.RED).fg(Color.WHITE),
-                text(state.commandBar.errorMessage).bg(Color.RED).fg(Color.WHITE),
-                text(" ").bg(Color.RED).fg(Color.WHITE).fill()
-            )
-        } else {
-            row(
-                text(":").fg(PRIMARY_COLOR),
-                text(state.commandBar.input).fg(TEXT_PRIMARY),
-                text("▌").fg(PRIMARY_COLOR)
-            )
-        }
-
-        content.render(frame, overlayArea, context)
+fun buildCommandBar(
+    state: MeloState,
+    onKeyEvent: (KeyEvent) -> EventResult
+): Element {
+    val content = if (state.commandBar.errorMessage != null) {
+        row(
+            text(" ").bg(Color.RED).fg(Color.WHITE),
+            text(state.commandBar.errorMessage).bg(Color.RED).fg(Color.WHITE),
+            text(" ").bg(Color.RED).fg(Color.WHITE).fill()
+        )
+    } else {
+        row(
+            text(":").fg(PRIMARY_COLOR),
+            text(state.commandBar.input).fg(TEXT_PRIMARY),
+            text("▌").fg(PRIMARY_COLOR),
+            spacer()
+        )
     }
 
-    override fun preferredSize(
-        availableWidth: Int,
-        availableHeight: Int,
-        context: RenderContext
-    ): Size =
-        Size.UNKNOWN
-
-    override fun constraint(): Constraint = Constraint.fill()
-    override fun handleKeyEvent(event: KeyEvent, focused: Boolean): EventResult =
-        EventResult.UNHANDLED
+    return content
+        .focusable()
+        .id("command-bar")
+        .onKeyEvent(onKeyEvent)
 }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/CommandBarOverlay.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/CommandBarOverlay.kt
@@ -1,0 +1,55 @@
+package com.github.adriianh.cli.tui.component
+
+import com.github.adriianh.cli.tui.MeloState
+import com.github.adriianh.cli.tui.MeloTheme.PRIMARY_COLOR
+import com.github.adriianh.cli.tui.MeloTheme.TEXT_PRIMARY
+import dev.tamboui.layout.Constraint
+import dev.tamboui.layout.Rect
+import dev.tamboui.style.Color
+import dev.tamboui.terminal.Frame
+import dev.tamboui.toolkit.Toolkit.*
+import dev.tamboui.toolkit.element.Element
+import dev.tamboui.toolkit.element.RenderContext
+import dev.tamboui.toolkit.element.Size
+import dev.tamboui.toolkit.event.EventResult
+import dev.tamboui.tui.event.KeyEvent
+
+class CommandBarOverlay(private val stateProvider: () -> MeloState) : Element {
+    override fun render(frame: Frame, area: Rect, context: RenderContext) {
+        val state = stateProvider()
+        if (!state.commandBar.isVisible) return
+
+        val overlayH = 1
+        val overlayW = area.width()
+        val overlayX = area.x()
+        val overlayY = area.y() + area.height() - overlayH
+        val overlayArea = Rect(overlayX, overlayY, overlayW, overlayH)
+        frame.buffer().clear(overlayArea)
+        val content = if (state.commandBar.errorMessage != null) {
+            row(
+                text(" ").bg(Color.RED).fg(Color.WHITE),
+                text(state.commandBar.errorMessage).bg(Color.RED).fg(Color.WHITE),
+                text(" ").bg(Color.RED).fg(Color.WHITE).fill()
+            )
+        } else {
+            row(
+                text(":").fg(PRIMARY_COLOR),
+                text(state.commandBar.input).fg(TEXT_PRIMARY),
+                text("▌").fg(PRIMARY_COLOR)
+            )
+        }
+
+        content.render(frame, overlayArea, context)
+    }
+
+    override fun preferredSize(
+        availableWidth: Int,
+        availableHeight: Int,
+        context: RenderContext
+    ): Size =
+        Size.UNKNOWN
+
+    override fun constraint(): Constraint = Constraint.fill()
+    override fun handleKeyEvent(event: KeyEvent, focused: Boolean): EventResult =
+        EventResult.UNHANDLED
+}

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/CommandBarSuggestionsOverlay.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/CommandBarSuggestionsOverlay.kt
@@ -1,0 +1,67 @@
+package com.github.adriianh.cli.tui.component
+
+import com.github.adriianh.cli.tui.MeloState
+import com.github.adriianh.cli.tui.MeloTheme
+import com.github.adriianh.cli.tui.graphics.ClearGraphicsWidget
+import dev.tamboui.layout.Constraint
+import dev.tamboui.layout.Rect
+import dev.tamboui.terminal.Frame
+import dev.tamboui.toolkit.Toolkit.column
+import dev.tamboui.toolkit.Toolkit.panel
+import dev.tamboui.toolkit.Toolkit.row
+import dev.tamboui.toolkit.Toolkit.spacer
+import dev.tamboui.toolkit.Toolkit.text
+import dev.tamboui.toolkit.element.Element
+import dev.tamboui.toolkit.element.RenderContext
+import dev.tamboui.toolkit.element.Size
+import dev.tamboui.toolkit.event.EventResult
+import dev.tamboui.tui.event.KeyEvent
+
+class CommandBarSuggestionsOverlay(
+    private val stateProvider: () -> MeloState
+) : Element {
+    private val clearGraphics = ClearGraphicsWidget()
+    override fun render(frame: Frame, area: Rect, context: RenderContext) {
+        val state = stateProvider()
+        val commandBarState = state.commandBar
+        if (!commandBarState.isVisible || commandBarState.suggestions.isEmpty()) {
+            return
+        }
+        val items = commandBarState.suggestions.mapIndexed { index, suggestion ->
+            val isSelected = index == commandBarState.selectedSuggestionIndex
+            row(
+                text(if (isSelected) " > " else "   ").fg(MeloTheme.TEXT_PRIMARY),
+                text(suggestion).fg(if (isSelected) MeloTheme.TEXT_PRIMARY else MeloTheme.TEXT_SECONDARY)
+                    .fill()
+            ).length(1)
+        }
+        val overlayW = area.width()
+        val overlayH = items.size + 2
+        val overlayX = area.x()
+        // Determine Y based on height of suggestions, put it just above the command bar
+        val overlayY = area.y() + area.height() - (overlayH + 1)
+        val overlayArea = Rect(overlayX, overlayY, overlayW, overlayH)
+        frame.renderWidget(clearGraphics, overlayArea)
+        frame.buffer().clear(overlayArea)
+        val hint = "[Tab] Complete - [Enter] Execute - [Esc] Cancel"
+        val subtitle = "Commands"
+        panel(
+            column(*items.toTypedArray()),
+            spacer(),
+            text(hint).fg(MeloTheme.TEXT_DIM).centered()
+        )
+            .title(subtitle)
+            .rounded()
+            .borderColor(MeloTheme.BORDER_FOCUSED)
+            .render(frame, overlayArea, context)
+    }
+
+    override fun preferredSize(
+        availableWidth: Int, availableHeight: Int, context: RenderContext
+    ): Size = Size.UNKNOWN
+
+    override fun constraint(): Constraint = Constraint.fill()
+    override fun handleKeyEvent(event: KeyEvent, focused: Boolean): EventResult {
+        return EventResult.UNHANDLED
+    }
+}

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/screen/MeloScreenRendering.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/screen/MeloScreenRendering.kt
@@ -4,10 +4,12 @@ import com.github.adriianh.cli.tui.MeloScreen
 import com.github.adriianh.cli.tui.PlaylistInputMode
 import com.github.adriianh.cli.tui.ScreenState
 import com.github.adriianh.cli.tui.SidebarSection
+import com.github.adriianh.cli.tui.component.buildCommandBar
 import com.github.adriianh.cli.tui.component.buildPlayerBar
 import com.github.adriianh.cli.tui.component.buildSearchBar
 import com.github.adriianh.cli.tui.component.buildSidebar
 import com.github.adriianh.cli.tui.graphics.ClearGraphicsElement
+import com.github.adriianh.cli.tui.handler.CommandBarHandlers.handleCommandBarKey
 import com.github.adriianh.cli.tui.handler.handleHomeKey
 import com.github.adriianh.cli.tui.handler.handleLibraryKey
 import com.github.adriianh.cli.tui.handler.handleOfflineKey
@@ -40,6 +42,24 @@ import dev.tamboui.toolkit.Toolkit.stack
 import dev.tamboui.toolkit.element.Element
 
 internal fun MeloScreen.renderRoot(): Element {
+    val playerBar = buildPlayerBar(
+        state, ::formatDuration, ::handlePlayerBarKey,
+        ::togglePlayPause, ::adjustVolume, ::seekForward, ::seekBackward,
+        ::toggleShuffle, ::cycleRepeat, ::toggleQueue,
+    )
+
+    val bottomContent = if (state.commandBar.isVisible) {
+        dock()
+            .top(playerBar, Constraint.length(4))
+            .bottom(
+                buildCommandBar(state) {
+                    handleCommandBarKey(it)
+                }, Constraint.length(1)
+            )
+    } else {
+        playerBar
+    }
+
     val mainLayout = dock()
         .top(
             buildSearchBar(
@@ -51,12 +71,8 @@ internal fun MeloScreen.renderRoot(): Element {
             Constraint.length(3)
         )
         .bottom(
-            buildPlayerBar(
-                state, ::formatDuration, ::handlePlayerBarKey,
-                ::togglePlayPause, ::adjustVolume, ::seekForward, ::seekBackward,
-                ::toggleShuffle, ::cycleRepeat, ::toggleQueue,
-            ),
-            Constraint.length(4),
+            bottomContent,
+            Constraint.length(if (state.commandBar.isVisible) 5 else 4),
         )
         .left(
             buildSidebar(
@@ -84,17 +100,12 @@ internal fun MeloScreen.renderRoot(): Element {
             stack(withTrackOptions, searchSuggestionsOverlay)
         else withTrackOptions
 
-    val withCommandBar = if (state.commandBar.isVisible) stack(
-        withSearchSuggestions,
-        commandBarOverlay
-    ) else withSearchSuggestions
-
     return when (state.playlistInteraction.playlistInputMode) {
         PlaylistInputMode.CREATE,
-        PlaylistInputMode.RENAME -> stack(withCommandBar, playlistInputOverlay)
+        PlaylistInputMode.RENAME -> stack(withSearchSuggestions, playlistInputOverlay)
 
-        PlaylistInputMode.PICKER -> stack(withCommandBar, playlistPickerOverlay)
-        PlaylistInputMode.NONE -> withCommandBar
+        PlaylistInputMode.PICKER -> stack(withSearchSuggestions, playlistPickerOverlay)
+        PlaylistInputMode.NONE -> withSearchSuggestions
     }
 }
 

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/screen/MeloScreenRendering.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/screen/MeloScreenRendering.kt
@@ -100,12 +100,17 @@ internal fun MeloScreen.renderRoot(): Element {
             stack(withTrackOptions, searchSuggestionsOverlay)
         else withTrackOptions
 
+    val withCommandBarSuggestions =
+        if (state.commandBar.isVisible && state.commandBar.suggestions.isNotEmpty())
+            stack(withSearchSuggestions, commandBarSuggestionsOverlay)
+        else withSearchSuggestions
+
     return when (state.playlistInteraction.playlistInputMode) {
         PlaylistInputMode.CREATE,
-        PlaylistInputMode.RENAME -> stack(withSearchSuggestions, playlistInputOverlay)
+        PlaylistInputMode.RENAME -> stack(withCommandBarSuggestions, playlistInputOverlay)
 
-        PlaylistInputMode.PICKER -> stack(withSearchSuggestions, playlistPickerOverlay)
-        PlaylistInputMode.NONE -> withSearchSuggestions
+        PlaylistInputMode.PICKER -> stack(withCommandBarSuggestions, playlistPickerOverlay)
+        PlaylistInputMode.NONE -> withCommandBarSuggestions
     }
 }
 

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/screen/MeloScreenRendering.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/component/screen/MeloScreenRendering.kt
@@ -84,12 +84,17 @@ internal fun MeloScreen.renderRoot(): Element {
             stack(withTrackOptions, searchSuggestionsOverlay)
         else withTrackOptions
 
+    val withCommandBar = if (state.commandBar.isVisible) stack(
+        withSearchSuggestions,
+        commandBarOverlay
+    ) else withSearchSuggestions
+
     return when (state.playlistInteraction.playlistInputMode) {
         PlaylistInputMode.CREATE,
-        PlaylistInputMode.RENAME -> stack(withSearchSuggestions, playlistInputOverlay)
+        PlaylistInputMode.RENAME -> stack(withCommandBar, playlistInputOverlay)
 
-        PlaylistInputMode.PICKER -> stack(withSearchSuggestions, playlistPickerOverlay)
-        PlaylistInputMode.NONE -> withSearchSuggestions
+        PlaylistInputMode.PICKER -> stack(withCommandBar, playlistPickerOverlay)
+        PlaylistInputMode.NONE -> withCommandBar
     }
 }
 

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
@@ -76,6 +76,11 @@ object CommandBarHandlers {
                 exitProcess(0)
             }
 
+            "settings" -> {
+                applySidebarSelection(SidebarSection.SETTINGS)
+                activateSidebarSelection(SidebarSection.SETTINGS)
+            }
+
             "vol" -> {
                 val vol = arg?.toIntOrNull()
                 if (vol != null && vol in 0..100) {
@@ -159,10 +164,58 @@ object CommandBarHandlers {
                         )
                     }
 
+                    "statistics" -> {
+                        applySidebarSelection(SidebarSection.STATS); activateSidebarSelection(
+                            SidebarSection.STATS
+                        )
+                    }
+
+                    "downloads" -> {
+                        applySidebarSelection(SidebarSection.OFFLINE); activateSidebarSelection(
+                            SidebarSection.OFFLINE
+                        )
+                    }
+
                     else -> {
                         errorMessage = "Usage: goto <home|search|library|nowplaying>"
                         isVisible = true
                     }
+                }
+            }
+
+            "search", "track", "song" -> {
+                if (!arg.isNullOrBlank()) {
+                    applySidebarSelection(SidebarSection.SEARCH)
+                    activateSidebarSelection(SidebarSection.SEARCH)
+                    state = state.copy(
+                        screen = ScreenState.Search(
+                            query = arg,
+                            tab = SearchTab.SONGS
+                        )
+                    )
+                    searchInputState.setText(arg)
+                    performSearch()
+                } else {
+                    errorMessage = "Usage: track <name>"
+                    isVisible = true
+                }
+            }
+
+            "album" -> {
+                if (!arg.isNullOrBlank()) {
+                    applySidebarSelection(SidebarSection.SEARCH)
+                    activateSidebarSelection(SidebarSection.SEARCH)
+                    state = state.copy(
+                        screen = ScreenState.Search(
+                            query = arg,
+                            tab = SearchTab.ALBUMS
+                        )
+                    )
+                    searchInputState.setText(arg)
+                    performSearch()
+                } else {
+                    errorMessage = "Usage: album <name>"
+                    isVisible = true
                 }
             }
 
@@ -180,6 +233,24 @@ object CommandBarHandlers {
                     performSearch()
                 } else {
                     errorMessage = "Usage: artist <name>"
+                    isVisible = true
+                }
+            }
+
+            "playlist" -> {
+                if (!arg.isNullOrBlank()) {
+                    applySidebarSelection(SidebarSection.SEARCH)
+                    activateSidebarSelection(SidebarSection.SEARCH)
+                    state = state.copy(
+                        screen = ScreenState.Search(
+                            query = arg,
+                            tab = SearchTab.PLAYLISTS
+                        )
+                    )
+                    searchInputState.setText(arg)
+                    performSearch()
+                } else {
+                    errorMessage = "Usage: playlist <name>"
                     isVisible = true
                 }
             }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
@@ -8,6 +8,7 @@ import com.github.adriianh.cli.tui.SidebarSection
 import com.github.adriianh.cli.tui.component.screen.handleMediaSessionNext
 import com.github.adriianh.cli.tui.component.screen.handleMediaSessionPrevious
 import com.github.adriianh.cli.tui.handler.playback.clearQueue
+import com.github.adriianh.cli.tui.handler.playback.toggleQueue
 import com.github.adriianh.cli.tui.handler.search.performSearch
 import dev.tamboui.toolkit.event.EventResult
 import dev.tamboui.tui.event.KeyCode
@@ -15,6 +16,33 @@ import dev.tamboui.tui.event.KeyEvent
 import kotlin.system.exitProcess
 
 object CommandBarHandlers {
+    private val ALL_COMMANDS = listOf(
+        "q", "quit", "settings", "vol <0-100>", "skip", "next", "prev", "queue clear", "queue open",
+        "shuffle on", "shuffle off", "repeat off", "repeat one", "repeat all",
+        "pause", "play", "resume", "goto home", "goto search", "goto library",
+        "goto nowplaying", "goto statistics", "goto downloads", "search <name>",
+        "track <name>", "song <name>", "album <name>", "artist <name>", "playlist <name>"
+    )
+
+    fun computeSuggestions(input: String): List<String> {
+        val normalized = input.trim()
+        if (normalized.isBlank()) return ALL_COMMANDS
+        val parts = normalized.split(" ", limit = 2)
+        if (parts.size > 1) {
+            val cmd = parts[0]
+            val rest = parts[1]
+            val subCommands = ALL_COMMANDS.filter { it.startsWith("$cmd ", ignoreCase = true) }
+            if (subCommands.isNotEmpty()) {
+                val matches = subCommands.filter {
+                    it.substringAfter(" ").startsWith(rest, ignoreCase = true)
+                }
+                return matches.ifEmpty { subCommands }
+            }
+            return emptyList()
+        }
+        return ALL_COMMANDS.filter { it.startsWith(normalized, ignoreCase = true) }.take(5)
+    }
+
     fun MeloScreen.handleCommandBarKey(event: KeyEvent): EventResult {
         if (!state.commandBar.isVisible) return EventResult.UNHANDLED
         val barState = state.commandBar
@@ -26,6 +54,22 @@ object CommandBarHandlers {
 
             KeyCode.ENTER -> {
                 val input = barState.input.trim()
+                if (barState.selectedSuggestionIndex != null && barState.suggestions.isNotEmpty() && input.isBlank()) {
+                    val sug = barState.suggestions[barState.selectedSuggestionIndex]
+                    val parts = sug.split(" ")
+                    val word =
+                        if (parts.size > 1 && parts[1].startsWith("<")) parts[0] + " " else sug
+                    state = state.copy(
+                        commandBar = barState.copy(
+                            input = word,
+                            cursorPosition = word.length,
+                            suggestions = computeSuggestions(word),
+                            selectedSuggestionIndex = null
+                        )
+                    )
+                    return EventResult.HANDLED
+                }
+
                 if (input.isNotEmpty()) {
                     executeCommand(input)
                 } else {
@@ -34,13 +78,64 @@ object CommandBarHandlers {
                 return EventResult.HANDLED
             }
 
-            KeyCode.BACKSPACE -> {
-                if (barState.input.isNotEmpty()) {
+            KeyCode.UP -> {
+                if (barState.suggestions.isNotEmpty()) {
+                    val prevIndex = if (barState.selectedSuggestionIndex == null) -1 else maxOf(
+                        -1,
+                        barState.selectedSuggestionIndex - 1
+                    )
                     state = state.copy(
                         commandBar = barState.copy(
-                            input = barState.input.substring(0, barState.input.length - 1),
+                            selectedSuggestionIndex = if (prevIndex == -1) null else prevIndex
+                        )
+                    )
+                }
+                return EventResult.HANDLED
+            }
+
+            KeyCode.DOWN -> {
+                if (barState.suggestions.isNotEmpty()) {
+                    val nextIndex = if (barState.selectedSuggestionIndex == null) 0 else minOf(
+                        barState.suggestions.size - 1,
+                        barState.selectedSuggestionIndex + 1
+                    )
+                    state = state.copy(
+                        commandBar = barState.copy(
+                            selectedSuggestionIndex = nextIndex
+                        )
+                    )
+                }
+                return EventResult.HANDLED
+            }
+
+            KeyCode.TAB -> {
+                if (barState.selectedSuggestionIndex != null && barState.suggestions.isNotEmpty()) {
+                    val sug = barState.suggestions[barState.selectedSuggestionIndex]
+                    val parts = sug.split(" ")
+                    val word =
+                        if (parts.size > 1 && parts[1].startsWith("<")) parts[0] + " " else sug
+                    state = state.copy(
+                        commandBar = barState.copy(
+                            input = word,
+                            cursorPosition = word.length,
+                            suggestions = computeSuggestions(word),
+                            selectedSuggestionIndex = null
+                        )
+                    )
+                }
+                return EventResult.HANDLED
+            }
+
+            KeyCode.BACKSPACE -> {
+                if (barState.input.isNotEmpty()) {
+                    val newInput = barState.input.substring(0, barState.input.length - 1)
+                    state = state.copy(
+                        commandBar = barState.copy(
+                            input = newInput,
                             cursorPosition = maxOf(0, barState.cursorPosition - 1),
-                            errorMessage = null
+                            errorMessage = null,
+                            suggestions = computeSuggestions(newInput),
+                            selectedSuggestionIndex = null
                         )
                     )
                 }
@@ -49,11 +144,14 @@ object CommandBarHandlers {
 
             KeyCode.CHAR -> {
                 val c = event.character()
+                val newInput = barState.input + c
                 state = state.copy(
                     commandBar = barState.copy(
-                        input = barState.input + c,
+                        input = newInput,
                         cursorPosition = barState.cursorPosition + 1,
-                        errorMessage = null
+                        errorMessage = null,
+                        suggestions = computeSuggestions(newInput),
+                        selectedSuggestionIndex = null
                     )
                 )
                 return EventResult.HANDLED
@@ -120,11 +218,13 @@ object CommandBarHandlers {
             }
 
             "queue" -> {
-                if (arg == "clear") {
-                    clearQueue()
-                } else {
-                    errorMessage = "Usage: queue clear"
-                    isVisible = true
+                when (arg) {
+                    "clear" -> clearQueue()
+                    "open" -> toggleQueue()
+                    else -> {
+                        errorMessage = "Usage: queue <clear>"
+                        isVisible = true
+                    }
                 }
             }
 

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
@@ -1,0 +1,202 @@
+package com.github.adriianh.cli.tui.handler
+
+import com.github.adriianh.cli.tui.MeloScreen
+import com.github.adriianh.cli.tui.RepeatMode
+import com.github.adriianh.cli.tui.ScreenState
+import com.github.adriianh.cli.tui.SearchTab
+import com.github.adriianh.cli.tui.SidebarSection
+import com.github.adriianh.cli.tui.component.screen.handleMediaSessionNext
+import com.github.adriianh.cli.tui.component.screen.handleMediaSessionPrevious
+import com.github.adriianh.cli.tui.handler.playback.clearQueue
+import com.github.adriianh.cli.tui.handler.search.performSearch
+import dev.tamboui.toolkit.event.EventResult
+import dev.tamboui.tui.event.KeyCode
+import dev.tamboui.tui.event.KeyEvent
+import kotlin.system.exitProcess
+
+object CommandBarHandlers {
+    fun MeloScreen.handleCommandBarKey(event: KeyEvent): EventResult {
+        if (!state.commandBar.isVisible) return EventResult.UNHANDLED
+        val barState = state.commandBar
+        when (event.code()) {
+            KeyCode.ESCAPE -> {
+                state = state.copy(commandBar = barState.copy(isVisible = false))
+                return EventResult.HANDLED
+            }
+
+            KeyCode.ENTER -> {
+                val input = barState.input.trim()
+                if (input.isNotEmpty()) {
+                    executeCommand(input)
+                } else {
+                    state = state.copy(commandBar = barState.copy(isVisible = false))
+                }
+                return EventResult.HANDLED
+            }
+
+            KeyCode.BACKSPACE -> {
+                if (barState.input.isNotEmpty()) {
+                    state = state.copy(
+                        commandBar = barState.copy(
+                            input = barState.input.substring(0, barState.input.length - 1),
+                            cursorPosition = maxOf(0, barState.cursorPosition - 1),
+                            errorMessage = null
+                        )
+                    )
+                }
+                return EventResult.HANDLED
+            }
+
+            KeyCode.CHAR -> {
+                val c = event.character()
+                state = state.copy(
+                    commandBar = barState.copy(
+                        input = barState.input + c,
+                        cursorPosition = barState.cursorPosition + 1,
+                        errorMessage = null
+                    )
+                )
+                return EventResult.HANDLED
+            }
+
+            else -> {}
+        }
+        return EventResult.HANDLED
+    }
+
+    private fun MeloScreen.executeCommand(input: String) {
+        val parts = input.split(" ", limit = 2)
+        val command = parts[0]
+        val arg = parts.getOrNull(1)
+        val newHistory = (state.commandBar.history + input).takeLast(50)
+        var errorMessage: String? = null
+        var isVisible = false
+        when (command) {
+            "q", "quit" -> {
+                exitProcess(0)
+            }
+
+            "vol" -> {
+                val vol = arg?.toIntOrNull()
+                if (vol != null && vol in 0..100) {
+                    audioPlayer.setVolume(vol)
+                    state = state.copy(player = state.player.copy(volume = vol))
+                } else {
+                    errorMessage = "Usage: vol <0-100>"
+                    isVisible = true
+                }
+            }
+
+            "skip", "next" -> {
+                handleMediaSessionNext()
+            }
+
+            "prev" -> {
+                handleMediaSessionPrevious()
+            }
+
+            "queue" -> {
+                if (arg == "clear") {
+                    clearQueue()
+                } else {
+                    errorMessage = "Usage: queue clear"
+                    isVisible = true
+                }
+            }
+
+            "shuffle" -> {
+                when (arg) {
+                    "on" -> state = state.copy(player = state.player.copy(shuffleEnabled = true))
+                    "off" -> state = state.copy(player = state.player.copy(shuffleEnabled = false))
+                    else -> {
+                        errorMessage = "Usage: shuffle <on|off>"
+                        isVisible = true
+                    }
+                }
+            }
+
+            "repeat" -> {
+                when (arg) {
+                    "off" -> state =
+                        state.copy(player = state.player.copy(repeatMode = RepeatMode.OFF))
+
+                    "one" -> state =
+                        state.copy(player = state.player.copy(repeatMode = RepeatMode.ONE))
+
+                    "all" -> state =
+                        state.copy(player = state.player.copy(repeatMode = RepeatMode.ALL))
+
+                    else -> {
+                        errorMessage = "Usage: repeat <off|one|all>"
+                        isVisible = true
+                    }
+                }
+            }
+
+            "goto" -> {
+                when (arg) {
+                    "home" -> {
+                        applySidebarSelection(SidebarSection.HOME); activateSidebarSelection(
+                            SidebarSection.HOME
+                        )
+                    }
+
+                    "search" -> {
+                        applySidebarSelection(SidebarSection.SEARCH); activateSidebarSelection(
+                            SidebarSection.SEARCH
+                        )
+                    }
+
+                    "library" -> {
+                        applySidebarSelection(SidebarSection.LIBRARY); activateSidebarSelection(
+                            SidebarSection.LIBRARY
+                        )
+                    }
+
+                    "nowplaying" -> {
+                        applySidebarSelection(SidebarSection.NOW_PLAYING); activateSidebarSelection(
+                            SidebarSection.NOW_PLAYING
+                        )
+                    }
+
+                    else -> {
+                        errorMessage = "Usage: goto <home|search|library|nowplaying>"
+                        isVisible = true
+                    }
+                }
+            }
+
+            "artist" -> {
+                if (!arg.isNullOrBlank()) {
+                    applySidebarSelection(SidebarSection.SEARCH)
+                    activateSidebarSelection(SidebarSection.SEARCH)
+                    state = state.copy(
+                        screen = ScreenState.Search(
+                            query = arg,
+                            tab = SearchTab.ARTISTS
+                        )
+                    )
+                    searchInputState.setText(arg)
+                    performSearch()
+                } else {
+                    errorMessage = "Usage: artist <name>"
+                    isVisible = true
+                }
+            }
+
+            else -> {
+                errorMessage = "Unrecognized command: $command"
+                isVisible = true
+            }
+        }
+        state = state.copy(
+            commandBar = state.commandBar.copy(
+                isVisible = isVisible,
+                input = if (isVisible) state.commandBar.input else "",
+                history = newHistory,
+                historyIndex = newHistory.size,
+                errorMessage = errorMessage
+            )
+        )
+    }
+}

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
@@ -157,6 +157,16 @@ object CommandBarHandlers {
                 }
             }
 
+            "pause" -> {
+                state = state.copy(player = state.player.copy(isPlaying = false))
+                audioPlayer.pause()
+            }
+
+            "play", "resume" -> {
+                state = state.copy(player = state.player.copy(isPlaying = true))
+                audioPlayer.resume()
+            }
+
             "goto" -> {
                 when (arg) {
                     "home" -> {

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
@@ -15,32 +15,265 @@ import dev.tamboui.tui.event.KeyCode
 import dev.tamboui.tui.event.KeyEvent
 import kotlin.system.exitProcess
 
+data class CommandResult(
+    val errorMessage: String? = null,
+    val keepBarOpen: Boolean = false,
+    val restoreFocus: Boolean = true
+)
+
+abstract class Command(
+    val names: List<String>,
+    val argumentDescription: String? = null,
+    val requiresArgument: Boolean = false
+) {
+    val suggestionTexts: List<String>
+        get() = names.map { if (argumentDescription != null) "$it $argumentDescription" else it }
+
+    abstract fun MeloScreen.execute(arg: String?): CommandResult
+}
+
 object CommandBarHandlers {
-    private val ALL_COMMANDS = listOf(
-        "q", "quit", "settings", "vol <0-100>", "skip", "next", "prev", "queue clear", "queue open",
-        "shuffle on", "shuffle off", "repeat off", "repeat one", "repeat all",
-        "pause", "play", "resume", "goto home", "goto search", "goto library",
-        "goto nowplaying", "goto statistics", "goto downloads", "search <name>",
-        "track <name>", "song <name>", "album <name>", "artist <name>", "playlist <name>"
+    private val COMMANDS = listOf(
+        object : Command(listOf("q", "quit")) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                exitProcess(0)
+            }
+        },
+        object : Command(listOf("settings")) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                applySidebarSelection(SidebarSection.SETTINGS)
+                activateSidebarSelection(SidebarSection.SETTINGS)
+                return CommandResult(restoreFocus = false)
+            }
+        },
+        object : Command(listOf("vol"), "<0-100>", requiresArgument = true) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                val vol = arg?.toIntOrNull()
+                return if (vol != null && vol in 0..100) {
+                    audioPlayer.setVolume(vol)
+                    state = state.copy(player = state.player.copy(volume = vol))
+                    CommandResult()
+                } else {
+                    CommandResult(errorMessage = "Usage: vol <0-100>", keepBarOpen = true)
+                }
+            }
+        },
+        object : Command(listOf("skip", "next")) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                handleMediaSessionNext()
+                return CommandResult()
+            }
+        },
+        object : Command(listOf("prev")) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                handleMediaSessionPrevious()
+                return CommandResult()
+            }
+        },
+        object : Command(listOf("queue"), "<clear|open>", requiresArgument = true) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                return when (arg) {
+                    "clear" -> {
+                        clearQueue()
+                        CommandResult()
+                    }
+
+                    "open" -> {
+                        toggleQueue()
+                        CommandResult()
+                    }
+
+                    else -> CommandResult(
+                        errorMessage = "Usage: queue <clear|open>",
+                        keepBarOpen = true
+                    )
+                }
+            }
+        },
+        object : Command(listOf("shuffle"), "<on|off>", requiresArgument = true) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                return when (arg) {
+                    "on" -> {
+                        state = state.copy(player = state.player.copy(shuffleEnabled = true))
+                        CommandResult()
+                    }
+
+                    "off" -> {
+                        state = state.copy(player = state.player.copy(shuffleEnabled = false))
+                        CommandResult()
+                    }
+
+                    else -> CommandResult(
+                        errorMessage = "Usage: shuffle <on|off>",
+                        keepBarOpen = true
+                    )
+                }
+            }
+        },
+        object : Command(listOf("repeat"), "<off|one|all>", requiresArgument = true) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                return when (arg) {
+                    "off" -> {
+                        state = state.copy(player = state.player.copy(repeatMode = RepeatMode.OFF))
+                        CommandResult()
+                    }
+
+                    "one" -> {
+                        state = state.copy(player = state.player.copy(repeatMode = RepeatMode.ONE))
+                        CommandResult()
+                    }
+
+                    "all" -> {
+                        state = state.copy(player = state.player.copy(repeatMode = RepeatMode.ALL))
+                        CommandResult()
+                    }
+
+                    else -> CommandResult(
+                        errorMessage = "Usage: repeat <off|one|all>",
+                        keepBarOpen = true
+                    )
+                }
+            }
+        },
+        object : Command(listOf("pause")) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                state = state.copy(player = state.player.copy(isPlaying = false))
+                audioPlayer.pause()
+                return CommandResult()
+            }
+        },
+        object : Command(listOf("play", "resume")) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                state = state.copy(player = state.player.copy(isPlaying = true))
+                audioPlayer.resume()
+                return CommandResult()
+            }
+        },
+        object : Command(
+            listOf("goto"),
+            "<home|search|library|nowplaying|statistics|downloads>",
+            requiresArgument = true
+        ) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                val section = when (arg) {
+                    "home" -> SidebarSection.HOME
+                    "search" -> SidebarSection.SEARCH
+                    "library" -> SidebarSection.LIBRARY
+                    "nowplaying" -> SidebarSection.NOW_PLAYING
+                    "statistics" -> SidebarSection.STATS
+                    "downloads" -> SidebarSection.OFFLINE
+                    else -> return CommandResult(
+                        errorMessage = "Usage: goto <home|search|library|nowplaying|statistics|downloads>",
+                        keepBarOpen = true
+                    )
+                }
+                applySidebarSelection(section)
+                activateSidebarSelection(section)
+                return CommandResult(restoreFocus = false)
+            }
+        },
+        object : Command(listOf("search", "track", "song"), "<name>", requiresArgument = true) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                return if (!arg.isNullOrBlank()) {
+                    applySidebarSelection(SidebarSection.SEARCH)
+                    activateSidebarSelection(SidebarSection.SEARCH)
+                    state =
+                        state.copy(screen = ScreenState.Search(query = arg, tab = SearchTab.SONGS))
+                    searchInputState.setText(arg)
+                    performSearch()
+                    CommandResult(restoreFocus = false)
+                } else {
+                    CommandResult(errorMessage = "Usage: track <name>", keepBarOpen = true)
+                }
+            }
+        },
+        object : Command(listOf("album"), "<name>", requiresArgument = true) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                return if (!arg.isNullOrBlank()) {
+                    applySidebarSelection(SidebarSection.SEARCH)
+                    activateSidebarSelection(SidebarSection.SEARCH)
+                    state =
+                        state.copy(screen = ScreenState.Search(query = arg, tab = SearchTab.ALBUMS))
+                    searchInputState.setText(arg)
+                    performSearch()
+                    CommandResult(restoreFocus = false)
+                } else {
+                    CommandResult(errorMessage = "Usage: album <name>", keepBarOpen = true)
+                }
+            }
+        },
+        object : Command(listOf("artist"), "<name>", requiresArgument = true) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                return if (!arg.isNullOrBlank()) {
+                    applySidebarSelection(SidebarSection.SEARCH)
+                    activateSidebarSelection(SidebarSection.SEARCH)
+                    state = state.copy(
+                        screen = ScreenState.Search(
+                            query = arg,
+                            tab = SearchTab.ARTISTS
+                        )
+                    )
+                    searchInputState.setText(arg)
+                    performSearch()
+                    CommandResult(restoreFocus = false)
+                } else {
+                    CommandResult(errorMessage = "Usage: artist <name>", keepBarOpen = true)
+                }
+            }
+        },
+        object : Command(listOf("playlist"), "<name>", requiresArgument = true) {
+            override fun MeloScreen.execute(arg: String?): CommandResult {
+                return if (!arg.isNullOrBlank()) {
+                    applySidebarSelection(SidebarSection.SEARCH)
+                    activateSidebarSelection(SidebarSection.SEARCH)
+                    state = state.copy(
+                        screen = ScreenState.Search(
+                            query = arg,
+                            tab = SearchTab.PLAYLISTS
+                        )
+                    )
+                    searchInputState.setText(arg)
+                    performSearch()
+                    CommandResult(restoreFocus = false)
+                } else {
+                    CommandResult(errorMessage = "Usage: playlist <name>", keepBarOpen = true)
+                }
+            }
+        }
     )
 
+    private val ALL_COMMANDS_FLAT = COMMANDS.flatMap { it.suggestionTexts }
+
     fun computeSuggestions(input: String): List<String> {
-        val normalized = input.trim()
-        if (normalized.isBlank()) return ALL_COMMANDS
-        val parts = normalized.split(" ", limit = 2)
-        if (parts.size > 1) {
-            val cmd = parts[0]
-            val rest = parts[1]
-            val subCommands = ALL_COMMANDS.filter { it.startsWith("$cmd ", ignoreCase = true) }
-            if (subCommands.isNotEmpty()) {
-                val matches = subCommands.filter {
-                    it.substringAfter(" ").startsWith(rest, ignoreCase = true)
-                }
-                return matches.ifEmpty { subCommands }
-            }
-            return emptyList()
+        val trimmed = input.trimStart()
+        if (trimmed.isBlank()) return ALL_COMMANDS_FLAT
+
+        val parts = trimmed.split(Regex("\\s+"), limit = 2)
+        val cmdInput = parts[0]
+        val argInput = parts.getOrNull(1)
+
+        val matchingCommands = COMMANDS.filter { cmd ->
+            cmd.names.any { it.contains(cmdInput, ignoreCase = true) }
         }
-        return ALL_COMMANDS.filter { it.startsWith(normalized, ignoreCase = true) }.take(5)
+
+        if (argInput != null) {
+            return matchingCommands.flatMap { cmd ->
+                if (cmd.requiresArgument) {
+                    cmd.names.filter { it.contains(cmdInput, ignoreCase = true) }
+                        .map { "$it ${cmd.argumentDescription ?: ""}" }
+                } else {
+                    emptyList()
+                }
+            }
+        }
+
+        return matchingCommands.flatMap { cmd ->
+            cmd.names.filter { it.contains(cmdInput, ignoreCase = true) }
+                .map { if (cmd.requiresArgument) "$it ${cmd.argumentDescription ?: ""}" else it }
+        }.sortedByDescending {
+            val baseName = it.split(" ").first()
+            baseName.startsWith(cmdInput, ignoreCase = true)
+        }.take(8)
     }
 
     fun MeloScreen.handleCommandBarKey(event: KeyEvent): EventResult {
@@ -53,25 +286,33 @@ object CommandBarHandlers {
             }
 
             KeyCode.ENTER -> {
-                val input = barState.input.trim()
-                if (barState.selectedSuggestionIndex != null && barState.suggestions.isNotEmpty() && input.isBlank()) {
+                var inputToExecute = barState.input.trim()
+
+                if (barState.selectedSuggestionIndex != null && barState.suggestions.isNotEmpty()) {
                     val sug = barState.suggestions[barState.selectedSuggestionIndex]
                     val parts = sug.split(" ")
-                    val word =
-                        if (parts.size > 1 && parts[1].startsWith("<")) parts[0] + " " else sug
-                    state = state.copy(
-                        commandBar = barState.copy(
-                            input = word,
-                            cursorPosition = word.length,
-                            suggestions = computeSuggestions(word),
-                            selectedSuggestionIndex = null
+                    val isTemplate = parts.size > 1 && parts[1].startsWith("<")
+                    val completedWord = if (isTemplate) parts[0] + " " else sug
+
+                    if (isTemplate && barState.input.trim().split(Regex("\\s+")).size == 1) {
+                        state = state.copy(
+                            commandBar = barState.copy(
+                                input = completedWord,
+                                cursorPosition = completedWord.length,
+                                suggestions = computeSuggestions(completedWord),
+                                selectedSuggestionIndex = null
+                            )
                         )
-                    )
-                    return EventResult.HANDLED
+                        return EventResult.HANDLED
+                    } else {
+                        if (!isTemplate) {
+                            inputToExecute = completedWord
+                        }
+                    }
                 }
 
-                if (input.isNotEmpty()) {
-                    executeCommand(input)
+                if (inputToExecute.isNotEmpty()) {
+                    executeCommand(inputToExecute)
                 } else {
                     closeCommandBar()
                 }
@@ -102,24 +343,6 @@ object CommandBarHandlers {
                     state = state.copy(
                         commandBar = barState.copy(
                             selectedSuggestionIndex = nextIndex
-                        )
-                    )
-                }
-                return EventResult.HANDLED
-            }
-
-            KeyCode.TAB -> {
-                if (barState.selectedSuggestionIndex != null && barState.suggestions.isNotEmpty()) {
-                    val sug = barState.suggestions[barState.selectedSuggestionIndex]
-                    val parts = sug.split(" ")
-                    val word =
-                        if (parts.size > 1 && parts[1].startsWith("<")) parts[0] + " " else sug
-                    state = state.copy(
-                        commandBar = barState.copy(
-                            input = word,
-                            cursorPosition = word.length,
-                            suggestions = computeSuggestions(word),
-                            selectedSuggestionIndex = null
                         )
                     )
                 }
@@ -181,235 +404,33 @@ object CommandBarHandlers {
 
     private fun MeloScreen.executeCommand(input: String) {
         val parts = input.split(" ", limit = 2)
-        val command = parts[0]
+        val commandName = parts[0]
         val arg = parts.getOrNull(1)
-        val newHistory = (state.commandBar.history + input).takeLast(50)
-        var errorMessage: String? = null
-        var isVisible = false
-        var restoreFocus = true
-        when (command) {
-            "q", "quit" -> {
-                exitProcess(0)
-            }
 
-            "settings" -> {
-                restoreFocus = false
-                applySidebarSelection(SidebarSection.SETTINGS)
-                activateSidebarSelection(SidebarSection.SETTINGS)
-            }
-
-            "vol" -> {
-                val vol = arg?.toIntOrNull()
-                if (vol != null && vol in 0..100) {
-                    audioPlayer.setVolume(vol)
-                    state = state.copy(player = state.player.copy(volume = vol))
-                } else {
-                    errorMessage = "Usage: vol <0-100>"
-                    isVisible = true
-                }
-            }
-
-            "skip", "next" -> {
-                handleMediaSessionNext()
-            }
-
-            "prev" -> {
-                handleMediaSessionPrevious()
-            }
-
-            "queue" -> {
-                when (arg) {
-                    "clear" -> clearQueue()
-                    "open" -> toggleQueue()
-                    else -> {
-                        errorMessage = "Usage: queue <clear>"
-                        isVisible = true
-                    }
-                }
-            }
-
-            "shuffle" -> {
-                when (arg) {
-                    "on" -> state = state.copy(player = state.player.copy(shuffleEnabled = true))
-                    "off" -> state = state.copy(player = state.player.copy(shuffleEnabled = false))
-                    else -> {
-                        errorMessage = "Usage: shuffle <on|off>"
-                        isVisible = true
-                    }
-                }
-            }
-
-            "repeat" -> {
-                when (arg) {
-                    "off" -> state =
-                        state.copy(player = state.player.copy(repeatMode = RepeatMode.OFF))
-
-                    "one" -> state =
-                        state.copy(player = state.player.copy(repeatMode = RepeatMode.ONE))
-
-                    "all" -> state =
-                        state.copy(player = state.player.copy(repeatMode = RepeatMode.ALL))
-
-                    else -> {
-                        errorMessage = "Usage: repeat <off|one|all>"
-                        isVisible = true
-                    }
-                }
-            }
-
-            "pause" -> {
-                state = state.copy(player = state.player.copy(isPlaying = false))
-                audioPlayer.pause()
-            }
-
-            "play", "resume" -> {
-                state = state.copy(player = state.player.copy(isPlaying = true))
-                audioPlayer.resume()
-            }
-
-            "goto" -> {
-                when (arg) {
-                    "home" -> {
-                        restoreFocus = false
-                        applySidebarSelection(SidebarSection.HOME); activateSidebarSelection(
-                            SidebarSection.HOME
-                        )
-                    }
-
-                    "search" -> {
-                        restoreFocus = false
-                        applySidebarSelection(SidebarSection.SEARCH); activateSidebarSelection(
-                            SidebarSection.SEARCH
-                        )
-                    }
-
-                    "library" -> {
-                        restoreFocus = false
-                        applySidebarSelection(SidebarSection.LIBRARY); activateSidebarSelection(
-                            SidebarSection.LIBRARY
-                        )
-                    }
-
-                    "nowplaying" -> {
-                        restoreFocus = false
-                        applySidebarSelection(SidebarSection.NOW_PLAYING); activateSidebarSelection(
-                            SidebarSection.NOW_PLAYING
-                        )
-                    }
-
-                    "statistics" -> {
-                        restoreFocus = false
-                        applySidebarSelection(SidebarSection.STATS)
-                        activateSidebarSelection(SidebarSection.STATS)
-                    }
-
-                    "downloads" -> {
-                        restoreFocus = false
-                        applySidebarSelection(SidebarSection.OFFLINE)
-                        activateSidebarSelection(SidebarSection.OFFLINE)
-                    }
-
-                    else -> {
-                        errorMessage =
-                            "Usage: goto <home|search|library|nowplaying|statistics|downloads>"
-                        isVisible = true
-                    }
-                }
-            }
-
-            "search", "track", "song" -> {
-                if (!arg.isNullOrBlank()) {
-                    restoreFocus = false
-                    applySidebarSelection(SidebarSection.SEARCH)
-                    activateSidebarSelection(SidebarSection.SEARCH)
-                    state = state.copy(
-                        screen = ScreenState.Search(
-                            query = arg,
-                            tab = SearchTab.SONGS
-                        )
-                    )
-                    searchInputState.setText(arg)
-                    performSearch()
-                } else {
-                    errorMessage = "Usage: track <name>"
-                    isVisible = true
-                }
-            }
-
-            "album" -> {
-                if (!arg.isNullOrBlank()) {
-                    restoreFocus = false
-                    applySidebarSelection(SidebarSection.SEARCH)
-                    activateSidebarSelection(SidebarSection.SEARCH)
-                    state = state.copy(
-                        screen = ScreenState.Search(
-                            query = arg,
-                            tab = SearchTab.ALBUMS
-                        )
-                    )
-                    searchInputState.setText(arg)
-                    performSearch()
-                } else {
-                    errorMessage = "Usage: album <name>"
-                    isVisible = true
-                }
-            }
-
-            "artist" -> {
-                if (!arg.isNullOrBlank()) {
-                    restoreFocus = false
-                    applySidebarSelection(SidebarSection.SEARCH)
-                    activateSidebarSelection(SidebarSection.SEARCH)
-                    state = state.copy(
-                        screen = ScreenState.Search(
-                            query = arg,
-                            tab = SearchTab.ARTISTS
-                        )
-                    )
-                    searchInputState.setText(arg)
-                    performSearch()
-                } else {
-                    errorMessage = "Usage: artist <name>"
-                    isVisible = true
-                }
-            }
-
-            "playlist" -> {
-                if (!arg.isNullOrBlank()) {
-                    restoreFocus = false
-                    applySidebarSelection(SidebarSection.SEARCH)
-                    activateSidebarSelection(SidebarSection.SEARCH)
-                    state = state.copy(
-                        screen = ScreenState.Search(
-                            query = arg,
-                            tab = SearchTab.PLAYLISTS
-                        )
-                    )
-                    searchInputState.setText(arg)
-                    performSearch()
-                } else {
-                    errorMessage = "Usage: playlist <name>"
-                    isVisible = true
-                }
-            }
-
-            else -> {
-                errorMessage = "Unrecognized command: $command"
-                isVisible = true
-            }
+        val command = COMMANDS.firstOrNull { cmd ->
+            cmd.names.any { it.equals(commandName, ignoreCase = true) }
         }
+
+        val newHistory = (state.commandBar.history + input).takeLast(50)
+
+        val result = if (command != null) {
+            command.run { execute(arg) }
+        } else {
+            CommandResult(errorMessage = "Unrecognized command: $commandName", keepBarOpen = true)
+        }
+
         state = state.copy(
             commandBar = state.commandBar.copy(
-                isVisible = isVisible,
-                input = if (isVisible) state.commandBar.input else "",
+                isVisible = result.keepBarOpen,
+                input = if (result.keepBarOpen) state.commandBar.input else "",
                 history = newHistory,
                 historyIndex = newHistory.size,
-                errorMessage = errorMessage,
-                previousFocusId = if (isVisible) state.commandBar.previousFocusId else null
+                errorMessage = result.errorMessage,
+                previousFocusId = if (result.keepBarOpen) state.commandBar.previousFocusId else null
             )
         )
 
-        if (!isVisible && restoreFocus) {
+        if (!result.keepBarOpen && result.restoreFocus) {
             val prevFocus = state.commandBar.previousFocusId
             if (prevFocus != null) {
                 appRunner()?.focusManager()?.setFocus(prevFocus)

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
@@ -210,7 +210,8 @@ object CommandBarHandlers {
                     }
 
                     else -> {
-                        errorMessage = "Usage: goto <home|search|library|nowplaying>"
+                        errorMessage =
+                            "Usage: goto <home|search|library|nowplaying|statistics|downloads>"
                         isVisible = true
                     }
                 }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
@@ -250,16 +250,15 @@ object CommandBarHandlers {
 
         val parts = trimmed.split(Regex("\\s+"), limit = 2)
         val cmdInput = parts[0]
-        val argInput = parts.getOrNull(1)
+        val hasSpace = trimmed.length > cmdInput.length
 
-        val matchingCommands = COMMANDS.filter { cmd ->
-            cmd.names.any { it.contains(cmdInput, ignoreCase = true) }
-        }
-
-        if (argInput != null) {
+        if (hasSpace) {
+            val matchingCommands = COMMANDS.filter { cmd ->
+                cmd.names.any { it.equals(cmdInput, ignoreCase = true) }
+            }
             return matchingCommands.flatMap { cmd ->
                 if (cmd.requiresArgument) {
-                    cmd.names.filter { it.contains(cmdInput, ignoreCase = true) }
+                    cmd.names.filter { it.equals(cmdInput, ignoreCase = true) }
                         .map { "$it ${cmd.argumentDescription ?: ""}" }
                 } else {
                     emptyList()
@@ -267,13 +266,16 @@ object CommandBarHandlers {
             }
         }
 
-        return matchingCommands.flatMap { cmd ->
+        return COMMANDS.flatMap { cmd ->
             cmd.names.filter { it.contains(cmdInput, ignoreCase = true) }
                 .map { if (cmd.requiresArgument) "$it ${cmd.argumentDescription ?: ""}" else it }
-        }.sortedByDescending {
-            val baseName = it.split(" ").first()
-            baseName.startsWith(cmdInput, ignoreCase = true)
-        }.take(8)
+        }.sortedWith(
+            compareByDescending<String> {
+                it.split(" ").first().equals(cmdInput, ignoreCase = true)
+            }
+                .thenByDescending { it.split(" ").first().startsWith(cmdInput, ignoreCase = true) }
+                .thenBy { it }
+        ).take(8)
     }
 
     fun MeloScreen.handleCommandBarKey(event: KeyEvent): EventResult {
@@ -413,11 +415,11 @@ object CommandBarHandlers {
 
         val newHistory = (state.commandBar.history + input).takeLast(50)
 
-        val result = if (command != null) {
-            command.run { execute(arg) }
-        } else {
-            CommandResult(errorMessage = "Unrecognized command: $commandName", keepBarOpen = true)
-        }
+        val result = command?.run { execute(arg) }
+            ?: CommandResult(
+                errorMessage = "Unrecognized command: $commandName",
+                keepBarOpen = true
+            )
 
         state = state.copy(
             commandBar = state.commandBar.copy(

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/CommandBarHandlers.kt
@@ -20,7 +20,7 @@ object CommandBarHandlers {
         val barState = state.commandBar
         when (event.code()) {
             KeyCode.ESCAPE -> {
-                state = state.copy(commandBar = barState.copy(isVisible = false))
+                closeCommandBar()
                 return EventResult.HANDLED
             }
 
@@ -29,7 +29,7 @@ object CommandBarHandlers {
                 if (input.isNotEmpty()) {
                     executeCommand(input)
                 } else {
-                    state = state.copy(commandBar = barState.copy(isVisible = false))
+                    closeCommandBar()
                 }
                 return EventResult.HANDLED
             }
@@ -64,6 +64,23 @@ object CommandBarHandlers {
         return EventResult.HANDLED
     }
 
+    private fun MeloScreen.closeCommandBar(restoreFocus: Boolean = true) {
+        val prevFocus = state.commandBar.previousFocusId
+        state = state.copy(
+            commandBar = state.commandBar.copy(
+                isVisible = false,
+                previousFocusId = null
+            )
+        )
+        if (restoreFocus) {
+            if (prevFocus != null) {
+                appRunner()?.focusManager()?.setFocus(prevFocus)
+            } else {
+                appRunner()?.focusManager()?.setFocus("home-panel")
+            }
+        }
+    }
+
     private fun MeloScreen.executeCommand(input: String) {
         val parts = input.split(" ", limit = 2)
         val command = parts[0]
@@ -71,12 +88,14 @@ object CommandBarHandlers {
         val newHistory = (state.commandBar.history + input).takeLast(50)
         var errorMessage: String? = null
         var isVisible = false
+        var restoreFocus = true
         when (command) {
             "q", "quit" -> {
                 exitProcess(0)
             }
 
             "settings" -> {
+                restoreFocus = false
                 applySidebarSelection(SidebarSection.SETTINGS)
                 activateSidebarSelection(SidebarSection.SETTINGS)
             }
@@ -141,39 +160,43 @@ object CommandBarHandlers {
             "goto" -> {
                 when (arg) {
                     "home" -> {
+                        restoreFocus = false
                         applySidebarSelection(SidebarSection.HOME); activateSidebarSelection(
                             SidebarSection.HOME
                         )
                     }
 
                     "search" -> {
+                        restoreFocus = false
                         applySidebarSelection(SidebarSection.SEARCH); activateSidebarSelection(
                             SidebarSection.SEARCH
                         )
                     }
 
                     "library" -> {
+                        restoreFocus = false
                         applySidebarSelection(SidebarSection.LIBRARY); activateSidebarSelection(
                             SidebarSection.LIBRARY
                         )
                     }
 
                     "nowplaying" -> {
+                        restoreFocus = false
                         applySidebarSelection(SidebarSection.NOW_PLAYING); activateSidebarSelection(
                             SidebarSection.NOW_PLAYING
                         )
                     }
 
                     "statistics" -> {
-                        applySidebarSelection(SidebarSection.STATS); activateSidebarSelection(
-                            SidebarSection.STATS
-                        )
+                        restoreFocus = false
+                        applySidebarSelection(SidebarSection.STATS)
+                        activateSidebarSelection(SidebarSection.STATS)
                     }
 
                     "downloads" -> {
-                        applySidebarSelection(SidebarSection.OFFLINE); activateSidebarSelection(
-                            SidebarSection.OFFLINE
-                        )
+                        restoreFocus = false
+                        applySidebarSelection(SidebarSection.OFFLINE)
+                        activateSidebarSelection(SidebarSection.OFFLINE)
                     }
 
                     else -> {
@@ -185,6 +208,7 @@ object CommandBarHandlers {
 
             "search", "track", "song" -> {
                 if (!arg.isNullOrBlank()) {
+                    restoreFocus = false
                     applySidebarSelection(SidebarSection.SEARCH)
                     activateSidebarSelection(SidebarSection.SEARCH)
                     state = state.copy(
@@ -203,6 +227,7 @@ object CommandBarHandlers {
 
             "album" -> {
                 if (!arg.isNullOrBlank()) {
+                    restoreFocus = false
                     applySidebarSelection(SidebarSection.SEARCH)
                     activateSidebarSelection(SidebarSection.SEARCH)
                     state = state.copy(
@@ -221,6 +246,7 @@ object CommandBarHandlers {
 
             "artist" -> {
                 if (!arg.isNullOrBlank()) {
+                    restoreFocus = false
                     applySidebarSelection(SidebarSection.SEARCH)
                     activateSidebarSelection(SidebarSection.SEARCH)
                     state = state.copy(
@@ -239,6 +265,7 @@ object CommandBarHandlers {
 
             "playlist" -> {
                 if (!arg.isNullOrBlank()) {
+                    restoreFocus = false
                     applySidebarSelection(SidebarSection.SEARCH)
                     activateSidebarSelection(SidebarSection.SEARCH)
                     state = state.copy(
@@ -266,8 +293,18 @@ object CommandBarHandlers {
                 input = if (isVisible) state.commandBar.input else "",
                 history = newHistory,
                 historyIndex = newHistory.size,
-                errorMessage = errorMessage
+                errorMessage = errorMessage,
+                previousFocusId = if (isVisible) state.commandBar.previousFocusId else null
             )
         )
+
+        if (!isVisible && restoreFocus) {
+            val prevFocus = state.commandBar.previousFocusId
+            if (prevFocus != null) {
+                appRunner()?.focusManager()?.setFocus(prevFocus)
+            } else {
+                appRunner()?.focusManager()?.setFocus("home-panel")
+            }
+        }
     }
 }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenHomeHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenHomeHandlers.kt
@@ -16,12 +16,12 @@ import dev.tamboui.tui.event.KeyEvent
  * Handles key events for the Home screen, including Recent and Favorites sections.
  */
 internal fun MeloScreen.handleHomeKey(event: KeyEvent): EventResult {
-    val s = state.screen as? ScreenState.Home ?: return EventResult.UNHANDLED
+    val s = state.screen as? ScreenState.Home ?: return handleGlobalShortcuts(event)
     val focusedId = appRunner()?.focusManager()?.focusedId()
     val isFocused = focusedId == "home-panel"
             || focusedId == "home-recent-panel"
             || focusedId == "home-favorites-panel"
-    if (!isFocused) return EventResult.UNHANDLED
+    if (!isFocused) return handleGlobalShortcuts(event)
 
     if (focusedId == "home-recent-panel" && s.homeSection != HomeSection.RECENT) {
         updateScreen<ScreenState.Home> { it.copy(homeSection = HomeSection.RECENT) }
@@ -60,21 +60,21 @@ internal fun MeloScreen.handleHomeKey(event: KeyEvent): EventResult {
 
                 event.code() == KeyCode.ENTER -> {
                     val track = state.collections.recentTracks.getOrNull(s.homeRecentCursor)?.track
-                        ?: return EventResult.UNHANDLED
+                        ?: return handleGlobalShortcuts(event)
                     playTrack(track)
                     return EventResult.HANDLED
                 }
 
                 event.matchesAction(MeloAction.ADD_TO_QUEUE, settingsViewState.currentSettings) -> {
                     val track = state.collections.recentTracks.getOrNull(s.homeRecentCursor)?.track
-                        ?: return EventResult.UNHANDLED
+                        ?: return handleGlobalShortcuts(event)
                     addToQueue(track)
                     return EventResult.HANDLED
                 }
 
                 event.matchesAction(MeloAction.FAVORITE, settingsViewState.currentSettings) -> {
                     val track = state.collections.recentTracks.getOrNull(s.homeRecentCursor)?.track
-                        ?: return EventResult.UNHANDLED
+                        ?: return handleGlobalShortcuts(event)
                     toggleFavorite(track)
                     return EventResult.HANDLED
                 }
@@ -116,21 +116,24 @@ internal fun MeloScreen.handleHomeKey(event: KeyEvent): EventResult {
 
                 event.code() == KeyCode.ENTER -> {
                     val track =
-                        state.collections.favorites.getOrNull(s.homeFavoritesCursor) ?: return EventResult.UNHANDLED
+                        state.collections.favorites.getOrNull(s.homeFavoritesCursor)
+                            ?: return handleGlobalShortcuts(event)
                     playTrack(track)
                     return EventResult.HANDLED
                 }
 
                 event.matchesAction(MeloAction.ADD_TO_QUEUE, settingsViewState.currentSettings) -> {
                     val track =
-                        state.collections.favorites.getOrNull(s.homeFavoritesCursor) ?: return EventResult.UNHANDLED
+                        state.collections.favorites.getOrNull(s.homeFavoritesCursor)
+                            ?: return handleGlobalShortcuts(event)
                     addToQueue(track)
                     return EventResult.HANDLED
                 }
 
                 event.matchesAction(MeloAction.FAVORITE, settingsViewState.currentSettings) -> {
                     val track =
-                        state.collections.favorites.getOrNull(s.homeFavoritesCursor) ?: return EventResult.UNHANDLED
+                        state.collections.favorites.getOrNull(s.homeFavoritesCursor)
+                            ?: return handleGlobalShortcuts(event)
                     toggleFavorite(track)
                     return EventResult.HANDLED
                 }
@@ -144,5 +147,5 @@ internal fun MeloScreen.handleHomeKey(event: KeyEvent): EventResult {
         }
     }
 
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenKeyHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenKeyHandlers.kt
@@ -6,6 +6,7 @@ import com.github.adriianh.cli.tui.SidebarSection
 import com.github.adriianh.cli.tui.handler.playback.handlePlayerBarKey
 import com.github.adriianh.cli.tui.handler.playback.handleTrackOptionsKey
 import com.github.adriianh.cli.tui.handler.settings.handleSettingsKey
+import com.github.adriianh.cli.tui.handler.CommandBarHandlers.handleCommandBarKey
 import com.github.adriianh.core.domain.model.MeloAction
 import com.github.adriianh.core.domain.model.Settings
 import dev.tamboui.toolkit.event.EventResult
@@ -94,6 +95,8 @@ internal fun MeloScreen.applySidebarSelection(item: SidebarSection) {
 }
 
 internal fun MeloScreen.isTyping(): Boolean {
+    if (state.commandBar.isVisible) return true
+
     // Search bar is focused
     if (appRunner()?.focusManager()?.focusedId() == "search-bar") return true
 
@@ -102,14 +105,14 @@ internal fun MeloScreen.isTyping(): Boolean {
     if (libraryState?.isTyping == true) return true
 
     val offlineState = state.screen as? ScreenState.Offline
-    if (offlineState?.isTyping == true) return true
 
-    return false
+    return offlineState?.isTyping == true
 }
 
 internal fun MeloScreen.handleGlobalShortcuts(event: KeyEvent): EventResult {
     if (state.isSettingsVisible) return handleSettingsKey(event)
     if (state.trackOptions.isVisible) return handleTrackOptionsKey(event)
+    if (state.commandBar.isVisible) return handleCommandBarKey(event)
 
     val isTyping = isTyping()
     val isCharacter = event.code() == KeyCode.CHAR
@@ -125,6 +128,17 @@ internal fun MeloScreen.handleGlobalShortcuts(event: KeyEvent): EventResult {
 
     when (event.code()) {
         KeyCode.CHAR -> {
+            if (event.character() == ':') {
+                state = state.copy(
+                    commandBar = state.commandBar.copy(
+                        isVisible = true,
+                        input = "",
+                        errorMessage = null,
+                        cursorPosition = 0
+                    )
+                )
+                return EventResult.HANDLED
+            }
             if (event.character() == '/') {
                 applySidebarSelection(SidebarSection.SEARCH)
                 activateSidebarSelection(SidebarSection.SEARCH)

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenKeyHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenKeyHandlers.kt
@@ -3,10 +3,10 @@ package com.github.adriianh.cli.tui.handler
 import com.github.adriianh.cli.tui.MeloScreen
 import com.github.adriianh.cli.tui.ScreenState
 import com.github.adriianh.cli.tui.SidebarSection
+import com.github.adriianh.cli.tui.handler.CommandBarHandlers.handleCommandBarKey
 import com.github.adriianh.cli.tui.handler.playback.handlePlayerBarKey
 import com.github.adriianh.cli.tui.handler.playback.handleTrackOptionsKey
 import com.github.adriianh.cli.tui.handler.settings.handleSettingsKey
-import com.github.adriianh.cli.tui.handler.CommandBarHandlers.handleCommandBarKey
 import com.github.adriianh.core.domain.model.MeloAction
 import com.github.adriianh.core.domain.model.Settings
 import dev.tamboui.toolkit.event.EventResult
@@ -129,14 +129,17 @@ internal fun MeloScreen.handleGlobalShortcuts(event: KeyEvent): EventResult {
     when (event.code()) {
         KeyCode.CHAR -> {
             if (event.character() == ':') {
+                val currentFocus = appRunner()?.focusManager()?.focusedId()
                 state = state.copy(
                     commandBar = state.commandBar.copy(
                         isVisible = true,
                         input = "",
                         errorMessage = null,
-                        cursorPosition = 0
+                        cursorPosition = 0,
+                        previousFocusId = currentFocus
                     )
                 )
+                appRunner()?.focusManager()?.setFocus("command-bar")
                 return EventResult.HANDLED
             }
             if (event.character() == '/') {

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenKeyHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenKeyHandlers.kt
@@ -117,13 +117,11 @@ internal fun MeloScreen.handleGlobalShortcuts(event: KeyEvent): EventResult {
     val isTyping = isTyping()
     val isCharacter = event.code() == KeyCode.CHAR
 
-    // Skip playback keys if typing a character in an input
     if (!(isTyping && isCharacter)) {
         val handled = handlePlayerBarKey(event)
         if (handled == EventResult.HANDLED) return EventResult.HANDLED
     }
 
-    // If we're typing, we don't want global navigation shortcuts to trigger
     if (isTyping && isCharacter) return EventResult.UNHANDLED
 
     when (event.code()) {
@@ -136,7 +134,9 @@ internal fun MeloScreen.handleGlobalShortcuts(event: KeyEvent): EventResult {
                         input = "",
                         errorMessage = null,
                         cursorPosition = 0,
-                        previousFocusId = currentFocus
+                        previousFocusId = currentFocus,
+                        suggestions = CommandBarHandlers.computeSuggestions(""),
+                        selectedSuggestionIndex = null
                     )
                 )
                 appRunner()?.focusManager()?.setFocus("command-bar")

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenLibraryHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenLibraryHandlers.kt
@@ -24,9 +24,9 @@ internal fun MeloScreen.handleLibraryKey(event: KeyEvent): EventResult {
         PlaylistInputMode.NONE -> {}
     }
 
-    val actualState = state.screen as? ScreenState.Library ?: return EventResult.UNHANDLED
+    val actualState = state.screen as? ScreenState.Library ?: return handleGlobalShortcuts(event)
     val isFocused = appRunner()?.focusManager()?.focusedId() == "library-panel"
-    if (!isFocused) return EventResult.UNHANDLED
+    if (!isFocused) return handleGlobalShortcuts(event)
 
     if (event.code() == KeyCode.CHAR && event.character() == '1') {
         updateScreen<ScreenState.Library> { it.copy(libraryTab = LibraryTab.FAVORITES) }
@@ -53,7 +53,7 @@ internal fun MeloScreen.handleLibraryKey(event: KeyEvent): EventResult {
 }
 
 internal fun MeloScreen.handleLocalLibraryKey(event: KeyEvent): EventResult {
-    val actualState = state.screen as? ScreenState.Library ?: return EventResult.UNHANDLED
+    val actualState = state.screen as? ScreenState.Library ?: return handleGlobalShortcuts(event)
     val allPaths = settingsViewState.currentSettings.localLibraryPaths
 
     val filtered = actualState.localTracks.filter { track ->
@@ -145,7 +145,7 @@ internal fun MeloScreen.handleLocalLibraryKey(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }
 
 internal fun MeloScreen.handleFavoritesKey(event: KeyEvent): EventResult {
@@ -188,5 +188,5 @@ internal fun MeloScreen.handleFavoritesKey(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenOfflineHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenOfflineHandlers.kt
@@ -14,7 +14,7 @@ import dev.tamboui.tui.event.KeyEvent
  * Handles key events for the Offline (Downloads) screen.
  */
 internal fun MeloScreen.handleOfflineKey(event: KeyEvent): EventResult {
-    val actualState = state.screen as? ScreenState.Offline ?: return EventResult.UNHANDLED
+    val actualState = state.screen as? ScreenState.Offline ?: return handleGlobalShortcuts(event)
 
     if (actualState.isTyping) {
         when {
@@ -93,5 +93,5 @@ internal fun MeloScreen.handleOfflineKey(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenPlaylistHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenPlaylistHandlers.kt
@@ -33,12 +33,14 @@ internal fun MeloScreen.handlePlaylistsKey(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
         event.code() == KeyCode.CHAR && event.character() == 'r' -> {
-            val pl = playlists.getOrNull(playlistsList.selected()) ?: return EventResult.UNHANDLED
+            val pl =
+                playlists.getOrNull(playlistsList.selected()) ?: return handleGlobalShortcuts(event)
             state = state.copy(playlistInteraction = state.playlistInteraction.copy(playlistInputMode = PlaylistInputMode.RENAME, playlistInput = pl.name))
             return EventResult.HANDLED
         }
         event.code() == KeyCode.CHAR && event.character() == 'd' || event.code() == KeyCode.DELETE -> {
-            val pl = playlists.getOrNull(playlistsList.selected()) ?: return EventResult.UNHANDLED
+            val pl =
+                playlists.getOrNull(playlistsList.selected()) ?: return handleGlobalShortcuts(event)
             scope.launch { deletePlaylist(pl.id) }
             return EventResult.HANDLED
         }
@@ -47,11 +49,11 @@ internal fun MeloScreen.handlePlaylistsKey(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }
 
 internal fun MeloScreen.handlePlaylistDetailKey(event: KeyEvent): EventResult {
-    val screen = state.screen as? ScreenState.Library ?: return EventResult.UNHANDLED
+    val screen = state.screen as? ScreenState.Library ?: return handleGlobalShortcuts(event)
     when {
         event.code() == KeyCode.ESCAPE -> {
             updateScreen<ScreenState.Library> { it.copy(isInPlaylistDetail = false, selectedPlaylist = null, playlistTracks = emptyList()) }
@@ -77,13 +79,14 @@ internal fun MeloScreen.handlePlaylistDetailKey(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
         event.code() == KeyCode.CHAR && event.character() == 'd' || event.code() == KeyCode.DELETE -> {
-            val pl = screen.selectedPlaylist ?: return EventResult.UNHANDLED
-            val track = screen.playlistTracks.getOrNull(playlistTracksList.selected()) ?: return EventResult.UNHANDLED
+            val pl = screen.selectedPlaylist ?: return handleGlobalShortcuts(event)
+            val track = screen.playlistTracks.getOrNull(playlistTracksList.selected())
+                ?: return handleGlobalShortcuts(event)
             scope.launch { removeTrackFromPlaylist(pl.id, track.id) }
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }
 
 internal fun MeloScreen.handlePlaylistInput(event: KeyEvent): EventResult {
@@ -120,7 +123,7 @@ internal fun MeloScreen.handlePlaylistInput(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }
 
 internal fun MeloScreen.handlePlaylistPicker(event: KeyEvent): EventResult {
@@ -140,14 +143,15 @@ internal fun MeloScreen.handlePlaylistPicker(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
         event.code() == KeyCode.ENTER -> {
-            val pl = playlists.getOrNull(interaction.playlistPickerCursor) ?: return EventResult.UNHANDLED
-            val track = interaction.playlistPickerTrack ?: return EventResult.UNHANDLED
+            val pl = playlists.getOrNull(interaction.playlistPickerCursor)
+                ?: return handleGlobalShortcuts(event)
+            val track = interaction.playlistPickerTrack ?: return handleGlobalShortcuts(event)
             scope.launch { addTrackToPlaylist(pl.id, track) }
             state = state.copy(playlistInteraction = interaction.copy(playlistInputMode = PlaylistInputMode.NONE, playlistPickerTrack = null))
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }
 
 // ─── Playlist Actions ─────────────────────────────────────────────────────────

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenStatsHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/MeloScreenStatsHandlers.kt
@@ -30,7 +30,7 @@ internal fun MeloScreen.loadStats(period: StatsPeriod? = null) {
 }
 
 internal fun MeloScreen.handleStatsKey(event: KeyEvent): EventResult {
-    val s = state.screen as? ScreenState.Stats ?: return EventResult.UNHANDLED
+    val s = state.screen as? ScreenState.Stats ?: return handleGlobalShortcuts(event)
     val periods = StatsPeriod.entries
     val units = StatsTimeUnit.entries
     val current = s.statsPeriod
@@ -56,5 +56,5 @@ internal fun MeloScreen.handleStatsKey(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/QueueHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/QueueHandlers.kt
@@ -1,6 +1,7 @@
 package com.github.adriianh.cli.tui.handler.playback
 
 import com.github.adriianh.cli.tui.MeloScreen
+import com.github.adriianh.cli.tui.handler.handleGlobalShortcuts
 import com.github.adriianh.cli.tui.handler.matchesAction
 import com.github.adriianh.cli.tui.isPlayable
 import com.github.adriianh.core.domain.model.MeloAction
@@ -105,7 +106,7 @@ internal fun MeloScreen.handleQueueKey(event: KeyEvent): EventResult {
         }
 
         event.matches(Actions.MOVE_DOWN) -> {
-            if (!isFocused) return EventResult.UNHANDLED
+            if (!isFocused) return handleGlobalShortcuts(event)
             val newCursor = minOf(state.player.queue.lastIndex, state.player.queueCursor + 1)
             state = state.copy(player = state.player.copy(queueCursor = newCursor))
 
@@ -116,7 +117,7 @@ internal fun MeloScreen.handleQueueKey(event: KeyEvent): EventResult {
         }
 
         event.matches(Actions.MOVE_UP) -> {
-            if (!isFocused) return EventResult.UNHANDLED
+            if (!isFocused) return handleGlobalShortcuts(event)
             state = state.copy(
                 player = state.player.copy(
                     queueCursor = maxOf(
@@ -129,7 +130,7 @@ internal fun MeloScreen.handleQueueKey(event: KeyEvent): EventResult {
         }
 
         event.code() == KeyCode.ENTER -> {
-            if (!isFocused) return EventResult.UNHANDLED
+            if (!isFocused) return handleGlobalShortcuts(event)
             if (state.player.queue.getOrNull(state.player.queueCursor) != null) playFromQueue(state.player.queueCursor)
             return EventResult.HANDLED
         }
@@ -138,7 +139,7 @@ internal fun MeloScreen.handleQueueKey(event: KeyEvent): EventResult {
             MeloAction.DELETE,
             settingsViewState.currentSettings
         ) || (event.code() == KeyCode.CHAR && event.character() == 'd') -> {
-            if (!isFocused) return EventResult.UNHANDLED
+            if (!isFocused) return handleGlobalShortcuts(event)
             removeFromQueue(state.player.queueCursor)
             return EventResult.HANDLED
         }
@@ -148,5 +149,5 @@ internal fun MeloScreen.handleQueueKey(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/TrackOptionsHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/playback/TrackOptionsHandlers.kt
@@ -2,6 +2,7 @@ package com.github.adriianh.cli.tui.handler.playback
 
 import com.github.adriianh.cli.tui.DetailTab
 import com.github.adriianh.cli.tui.MeloScreen
+import com.github.adriianh.cli.tui.handler.handleGlobalShortcuts
 import com.github.adriianh.cli.tui.handler.loadMoreSimilar
 import com.github.adriianh.cli.tui.handler.openPlaylistPicker
 import com.github.adriianh.cli.tui.handler.toggleFavorite
@@ -35,7 +36,7 @@ internal fun MeloScreen.handleTrackOptionsKey(event: KeyEvent): EventResult {
         }
 
         event.code() == KeyCode.ENTER -> {
-            val track = state.trackOptions.track ?: return EventResult.UNHANDLED
+            val track = state.trackOptions.track ?: return handleGlobalShortcuts(event)
             val actionIndex = state.trackOptions.selectedIndex
             state = state.copy(trackOptions = state.trackOptions.copy(isVisible = false))
 
@@ -62,7 +63,7 @@ internal fun MeloScreen.handleTrackOptionsKey(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }
 
 internal fun MeloScreen.openTrackOptions(track: Track) {

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/search/SearchDetailHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/search/SearchDetailHandlers.kt
@@ -468,12 +468,12 @@ internal fun MeloScreen.handleDetailKey(event: KeyEvent): EventResult {
             return EventResult.HANDLED
         }
     }
-    return EventResult.UNHANDLED
+    return handleGlobalShortcuts(event)
 }
 
 internal fun MeloScreen.handleEntityDetailKey(event: KeyEvent): EventResult {
-    val actualState = state.screen as? ScreenState.Search ?: return EventResult.UNHANDLED
-    if (!actualState.isInEntityDetail) return EventResult.UNHANDLED
+    val actualState = state.screen as? ScreenState.Search ?: return handleGlobalShortcuts(event)
+    if (!actualState.isInEntityDetail) return handleGlobalShortcuts(event)
 
     val isDescFocused = appRunner()?.focusManager()?.focusedId() == "desc-area"
     if (isDescFocused) {
@@ -485,7 +485,7 @@ internal fun MeloScreen.handleEntityDetailKey(event: KeyEvent): EventResult {
             appRunner()?.focusManager()?.setFocus(targetFocus)
             return EventResult.HANDLED
         }
-        return EventResult.UNHANDLED
+        return handleGlobalShortcuts(event)
     }
 
     if (state.detail.selectedEntity is SearchResult.Artist) {
@@ -748,7 +748,7 @@ internal fun MeloScreen.handleEntityDetailKey(event: KeyEvent): EventResult {
 
         event.code() == KeyCode.ENTER && listSize > 0 -> {
             val selectedIndex = entityTracksList.selected()
-            val track = tracks.getOrNull(selectedIndex) ?: return EventResult.UNHANDLED
+            val track = tracks.getOrNull(selectedIndex) ?: return handleGlobalShortcuts(event)
             downloadTrack(track, DownloadType.PREFETCH)
             playList(tracks, selectedIndex)
             return EventResult.HANDLED

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/search/SearchHandlers.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/handler/search/SearchHandlers.kt
@@ -519,7 +519,7 @@ internal fun MeloScreen.handleSearchBarKey(event: KeyEvent): EventResult {
         }
     }
 
-    val s = state.screen as? ScreenState.Search ?: return EventResult.UNHANDLED
+    val s = state.screen as? ScreenState.Search ?: return handleGlobalShortcuts(event)
     if (s.results.isNotEmpty() &&
         (event.matches(Actions.MOVE_DOWN) || event.matches(Actions.MOVE_UP))
     ) {
@@ -538,7 +538,7 @@ internal fun MeloScreen.handleResultsKey(event: KeyEvent): EventResult {
         PlaylistInputMode.NONE -> {}
     }
 
-    val actualState = state.screen as? ScreenState.Search ?: return EventResult.UNHANDLED
+    val actualState = state.screen as? ScreenState.Search ?: return handleGlobalShortcuts(event)
 
     if (event.modifiers().alt()) {
         if (event.code() == KeyCode.RIGHT) {
@@ -570,11 +570,11 @@ internal fun MeloScreen.handleResultsKey(event: KeyEvent): EventResult {
         SearchTab.PLAYLISTS -> actualState.playlistResults.size
     }
 
-    if (listSize == 0) return EventResult.UNHANDLED
+    if (listSize == 0) return handleGlobalShortcuts(event)
 
     when {
         event.matches(Actions.MOVE_DOWN) -> {
-            if (!isFocused) return EventResult.UNHANDLED
+            if (!isFocused) return handleGlobalShortcuts(event)
             val newIndex = minOf(listSize - 1, actualState.selectedIndex + 1)
             resultList.selected(newIndex)
             state = state.copy(
@@ -616,7 +616,7 @@ internal fun MeloScreen.handleResultsKey(event: KeyEvent): EventResult {
         }
 
         event.matches(Actions.MOVE_UP) -> {
-            if (!isFocused) return EventResult.UNHANDLED
+            if (!isFocused) return handleGlobalShortcuts(event)
             val newIndex = maxOf(0, actualState.selectedIndex - 1)
             resultList.selected(newIndex)
             state = state.copy(
@@ -656,11 +656,11 @@ internal fun MeloScreen.handleResultsKey(event: KeyEvent): EventResult {
         }
 
         event.code() == KeyCode.ENTER -> {
-            if (!isFocused) return EventResult.UNHANDLED
+            if (!isFocused) return handleGlobalShortcuts(event)
             when (actualState.tab) {
                 SearchTab.SONGS -> {
                     val selected = actualState.results.getOrNull(resultList.selected())
-                        ?: return EventResult.UNHANDLED
+                        ?: return handleGlobalShortcuts(event)
                     downloadTrack(selected, DownloadType.PREFETCH)
                     playTrack(selected)
                     return EventResult.HANDLED
@@ -668,21 +668,21 @@ internal fun MeloScreen.handleResultsKey(event: KeyEvent): EventResult {
 
                 SearchTab.ALBUMS -> {
                     val selected = actualState.albumResults.getOrNull(resultList.selected())
-                        ?: return EventResult.UNHANDLED
+                        ?: return handleGlobalShortcuts(event)
                     openEntityDetails(selected)
                     return EventResult.HANDLED
                 }
 
                 SearchTab.ARTISTS -> {
                     val selected = actualState.artistResults.getOrNull(resultList.selected())
-                        ?: return EventResult.UNHANDLED
+                        ?: return handleGlobalShortcuts(event)
                     openEntityDetails(selected)
                     return EventResult.HANDLED
                 }
 
                 SearchTab.PLAYLISTS -> {
                     val selected = actualState.playlistResults.getOrNull(resultList.selected())
-                        ?: return EventResult.UNHANDLED
+                        ?: return handleGlobalShortcuts(event)
                     openEntityDetails(selected)
                     return EventResult.HANDLED
                 }


### PR DESCRIPTION
## What
Add a vim-style command bar (`:`) for power-user actions without leaving the keyboard flow.
## Why
Users wanted more keyboard-oriented controls, especially power-users handling quick commands.
## Testing
- Manually checked opening bar by typing `:` on various screens.
- Executed commands like `:vol 50`, `:goto library`, `:artist some artist`.
- Successfully parsed history navigation.
Closes #14