### PR TITLE
fix: prevent search bar from hijacking focus on navigation

### DIFF
--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
@@ -200,7 +200,7 @@ class MeloScreen(
                 if (currentQuery != lastObservedSearchQuery) {
                     lastObservedSearchQuery = currentQuery
                     handleSearchQueryChange(currentQuery)
-                } else if (isFocused && !lastObservedFocus) {
+                } else if (isFocused && !lastObservedFocus && state.screen is ScreenState.Search) {
                     handleSearchQueryChange(currentQuery)
                 } else if (!isFocused && lastObservedFocus && state.screen is ScreenState.Search) {
                     updateScreen<ScreenState.Search> { it.copy(isShowingSuggestions = false) }

--- a/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
+++ b/cli/src/main/kotlin/com/github/adriianh/cli/tui/MeloScreen.kt
@@ -55,6 +55,7 @@ import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Semaphore
@@ -207,7 +208,7 @@ class MeloScreen(
                 }
 
                 lastObservedFocus = isFocused
-                kotlinx.coroutines.delay(100)
+                delay(100)
             }
         }
     }


### PR DESCRIPTION
#### fix: resolve focus hijacking in search bar

This PR addresses a UX issue where the search bar would automatically redirect the user to the Search screen upon receiving focus (e.g., via TAB navigation).

##### Fixed
- Modified `observeSearchInput` to only trigger search query logic on focus gain if the current screen is already `ScreenState.Search`.
- Restored normal TAB navigation flow on the Home screen, allowing users to focus on home panels without being forced into the search view.

##### Impact
- **Search Reactivity**: Typing in the search bar still triggers an automatic redirect to the search screen as expected.
- **Suggestions**: Suggestions are still correctly restored when refocusing the search bar while on the search screen.

---
**Commits:** 1 commit | `master ← fix/search-bar-focus-hijack`
